### PR TITLE
Add LoRa wireless metering system

### DIFF
--- a/AspNetCore8Test/Controllers/LoRaController.cs
+++ b/AspNetCore8Test/Controllers/LoRaController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCore8Test.Controllers
+{
+    public class LoRaController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/AspNetCore8Test/Controllers/LoRaSystemController.cs
+++ b/AspNetCore8Test/Controllers/LoRaSystemController.cs
@@ -1,0 +1,262 @@
+using AspNetCore8Test.Models.DTOs.LoRaDTOs;
+using AspNetCore8Test.Services.LoRaServices;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCore8Test.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class LoRaSystemController : ControllerBase
+    {
+        private readonly ILoRaSystemService _loRaSystemService;
+
+        public LoRaSystemController(ILoRaSystemService loRaSystemService)
+        {
+            _loRaSystemService = loRaSystemService;
+        }
+
+        [HttpGet("stats")]
+        public async Task<ActionResult<LoRaDashboardStatsDto>> GetStats()
+        {
+            try
+            {
+                var stats = await _loRaSystemService.GetDashboardStatsAsync();
+                return Ok(stats);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "載入 LoRa 統計資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpGet("gateways")]
+        public async Task<ActionResult<IEnumerable<LoRaGatewayDto>>> GetGateways()
+        {
+            try
+            {
+                var gateways = await _loRaSystemService.GetGatewaysAsync();
+                return Ok(gateways);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "載入閘道器資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpGet("devices")]
+        public async Task<ActionResult<IEnumerable<LoRaDeviceDto>>> GetDevices([FromQuery] string? status = null, [FromQuery] string? search = null, [FromQuery] int? gatewayId = null)
+        {
+            try
+            {
+                var devices = await _loRaSystemService.GetDevicesAsync(status, search, gatewayId);
+                return Ok(devices);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "載入設備資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpGet("devices/{id}")]
+        public async Task<ActionResult<LoRaDeviceDto>> GetDevice(int id)
+        {
+            try
+            {
+                var device = await _loRaSystemService.GetDeviceByIdAsync(id);
+                if (device == null)
+                {
+                    return NotFound(new { message = $"找不到編號為 {id} 的設備" });
+                }
+
+                return Ok(device);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "載入設備資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpPost("devices")]
+        public async Task<ActionResult<LoRaDeviceDto>> CreateDevice([FromBody] CreateLoRaDeviceDto dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                var device = await _loRaSystemService.AddDeviceAsync(dto);
+                return CreatedAtAction(nameof(GetDevice), new { id = device.Id }, device);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "新增設備時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpPut("devices/{id}")]
+        public async Task<IActionResult> UpdateDevice(int id, [FromBody] UpdateLoRaDeviceDto dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                var updated = await _loRaSystemService.UpdateDeviceAsync(id, dto);
+                if (!updated)
+                {
+                    return NotFound(new { message = $"找不到編號為 {id} 的設備" });
+                }
+
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "更新設備資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpDelete("devices/{id}")]
+        public async Task<IActionResult> DeleteDevice(int id)
+        {
+            try
+            {
+                var deleted = await _loRaSystemService.RemoveDeviceAsync(id);
+                if (!deleted)
+                {
+                    return NotFound(new { message = $"找不到編號為 {id} 的設備" });
+                }
+
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "刪除設備資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpGet("readings/latest")]
+        public async Task<ActionResult<IEnumerable<LoRaMeterReadingDto>>> GetLatestReadings([FromQuery] int? deviceId = null, [FromQuery] int count = 10)
+        {
+            try
+            {
+                if (count <= 0)
+                {
+                    count = 10;
+                }
+
+                var readings = await _loRaSystemService.GetLatestReadingsAsync(deviceId, count);
+                return Ok(readings);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "載入最新抄表資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpGet("devices/{id}/readings")]
+        public async Task<ActionResult<IEnumerable<LoRaMeterReadingDto>>> GetDeviceReadings(int id, [FromQuery] DateTime? from = null, [FromQuery] DateTime? to = null)
+        {
+            try
+            {
+                var readings = await _loRaSystemService.GetDeviceReadingsAsync(id, from, to);
+                return Ok(readings);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "載入抄表資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpPost("readings")]
+        public async Task<ActionResult<LoRaMeterReadingDto>> AddReading([FromBody] CreateLoRaMeterReadingDto dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                var reading = await _loRaSystemService.AddMeterReadingAsync(dto);
+                return CreatedAtAction(nameof(GetDeviceReadings), new { id = reading.DeviceId }, reading);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "新增抄表資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpGet("alerts")]
+        public async Task<ActionResult<IEnumerable<LoRaAlertDto>>> GetAlerts([FromQuery] string? status = null, [FromQuery] int? deviceId = null)
+        {
+            try
+            {
+                var alerts = await _loRaSystemService.GetAlertsAsync(status, deviceId);
+                return Ok(alerts);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "載入警報資料時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpPost("alerts")]
+        public async Task<ActionResult<LoRaAlertDto>> CreateAlert([FromBody] CreateLoRaAlertDto dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                var alert = await _loRaSystemService.CreateAlertAsync(dto);
+                return CreatedAtAction(nameof(GetAlerts), new { status = alert.Status }, alert);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "新增警報時發生錯誤", error = ex.Message });
+            }
+        }
+
+        [HttpPut("alerts/{id}/status")]
+        public async Task<IActionResult> UpdateAlertStatus(int id, [FromBody] UpdateLoRaAlertStatusDto dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                var updated = await _loRaSystemService.UpdateAlertStatusAsync(id, dto);
+                if (!updated)
+                {
+                    return NotFound(new { message = $"找不到編號為 {id} 的警報" });
+                }
+
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "更新警報狀態時發生錯誤", error = ex.Message });
+            }
+        }
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/CreateLoRaAlertDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/CreateLoRaAlertDto.cs
@@ -1,0 +1,11 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class CreateLoRaAlertDto
+    {
+        public int DeviceId { get; set; }
+        public string AlertType { get; set; } = string.Empty;
+        public string Severity { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/CreateLoRaDeviceDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/CreateLoRaDeviceDto.cs
@@ -1,0 +1,23 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class CreateLoRaDeviceDto
+    {
+        public string DeviceCode { get; set; } = string.Empty;
+        public string DeviceName { get; set; } = string.Empty;
+        public string MeterType { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public int? GatewayId { get; set; }
+        public string? Status { get; set; }
+        public DateTime? InstallDate { get; set; }
+        public string? FirmwareVersion { get; set; }
+        public decimal? InitialBatteryLevel { get; set; }
+        public int? InitialSignalStrength { get; set; }
+        public decimal? InitialSnr { get; set; }
+        public int TransmissionIntervalMinutes { get; set; }
+        public bool SupportsValveControl { get; set; }
+        public bool SupportsTwoWayCommunication { get; set; }
+        public string? Notes { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/CreateLoRaMeterReadingDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/CreateLoRaMeterReadingDto.cs
@@ -1,0 +1,19 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class CreateLoRaMeterReadingDto
+    {
+        public int DeviceId { get; set; }
+        public decimal Consumption { get; set; }
+        public DateTime? ReadingTime { get; set; }
+        public decimal? Temperature { get; set; }
+        public decimal? BatteryLevel { get; set; }
+        public decimal? BatteryVoltage { get; set; }
+        public int? Rssi { get; set; }
+        public decimal? Snr { get; set; }
+        public decimal? PacketLossRate { get; set; }
+        public string? ValveStatus { get; set; }
+        public string? TamperStatus { get; set; }
+        public bool? IsConfirmed { get; set; }
+        public string DataRate { get; set; } = string.Empty;
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaAlertDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaAlertDto.cs
@@ -1,0 +1,21 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class LoRaAlertDto
+    {
+        public int Id { get; set; }
+        public int DeviceId { get; set; }
+        public string DeviceCode { get; set; } = string.Empty;
+        public string DeviceName { get; set; } = string.Empty;
+        public string AlertType { get; set; } = string.Empty;
+        public string Severity { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public DateTime? AcknowledgedAt { get; set; }
+        public string? AcknowledgedBy { get; set; }
+        public DateTime? ResolvedAt { get; set; }
+        public string? ResolvedBy { get; set; }
+        public string? ResolutionNotes { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaDashboardStatsDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaDashboardStatsDto.cs
@@ -1,0 +1,18 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class LoRaDashboardStatsDto
+    {
+        public int TotalDevices { get; set; }
+        public int ActiveDevices { get; set; }
+        public int MaintenanceDevices { get; set; }
+        public int OfflineDevices { get; set; }
+        public int TotalGateways { get; set; }
+        public int GatewayOnline { get; set; }
+        public int GatewayOffline { get; set; }
+        public double AverageBatteryLevel { get; set; }
+        public double AverageSignalStrength { get; set; }
+        public int ActiveAlerts { get; set; }
+        public int DailyReadings { get; set; }
+        public int MonthlyReadings { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaDeviceDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaDeviceDto.cs
@@ -1,0 +1,28 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class LoRaDeviceDto
+    {
+        public int Id { get; set; }
+        public string DeviceCode { get; set; } = string.Empty;
+        public string DeviceName { get; set; } = string.Empty;
+        public string MeterType { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public decimal BatteryLevel { get; set; }
+        public int SignalStrength { get; set; }
+        public decimal Snr { get; set; }
+        public string FirmwareVersion { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public DateTime InstallDate { get; set; }
+        public DateTime LastCommunication { get; set; }
+        public int? GatewayId { get; set; }
+        public string? GatewayName { get; set; }
+        public int TransmissionIntervalMinutes { get; set; }
+        public bool SupportsValveControl { get; set; }
+        public bool SupportsTwoWayCommunication { get; set; }
+        public decimal? LastReadingValue { get; set; }
+        public DateTime? LastReadingAt { get; set; }
+        public string? Notes { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaGatewayDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaGatewayDto.cs
@@ -1,0 +1,23 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class LoRaGatewayDto
+    {
+        public int Id { get; set; }
+        public string GatewayCode { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public DateTime LastHeartbeat { get; set; }
+        public DateTime InstalledDate { get; set; }
+        public string FirmwareVersion { get; set; } = string.Empty;
+        public string ChannelPlan { get; set; } = string.Empty;
+        public string UplinkFrequency { get; set; } = string.Empty;
+        public string DownlinkFrequency { get; set; } = string.Empty;
+        public decimal CoverageRadiusKm { get; set; }
+        public string BackhaulType { get; set; } = string.Empty;
+        public double PacketForwardSuccessRate { get; set; }
+        public int ConnectedDevices { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaMeterReadingDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/LoRaMeterReadingDto.cs
@@ -1,0 +1,22 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class LoRaMeterReadingDto
+    {
+        public int Id { get; set; }
+        public int DeviceId { get; set; }
+        public string DeviceCode { get; set; } = string.Empty;
+        public string DeviceName { get; set; } = string.Empty;
+        public DateTime ReadingTime { get; set; }
+        public decimal Consumption { get; set; }
+        public decimal? Temperature { get; set; }
+        public decimal? BatteryLevel { get; set; }
+        public decimal? BatteryVoltage { get; set; }
+        public int? Rssi { get; set; }
+        public decimal? Snr { get; set; }
+        public decimal? PacketLossRate { get; set; }
+        public string? ValveStatus { get; set; }
+        public string? TamperStatus { get; set; }
+        public bool? IsConfirmed { get; set; }
+        public string DataRate { get; set; } = string.Empty;
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/UpdateLoRaAlertStatusDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/UpdateLoRaAlertStatusDto.cs
@@ -1,0 +1,9 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class UpdateLoRaAlertStatusDto
+    {
+        public string Status { get; set; } = string.Empty;
+        public string? ResolvedBy { get; set; }
+        public string? ResolutionNotes { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/DTOs/LoRaDTOs/UpdateLoRaDeviceDto.cs
+++ b/AspNetCore8Test/Models/DTOs/LoRaDTOs/UpdateLoRaDeviceDto.cs
@@ -1,0 +1,21 @@
+namespace AspNetCore8Test.Models.DTOs.LoRaDTOs
+{
+    public class UpdateLoRaDeviceDto
+    {
+        public string DeviceName { get; set; } = string.Empty;
+        public string MeterType { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public int? GatewayId { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public string FirmwareVersion { get; set; } = string.Empty;
+        public decimal BatteryLevel { get; set; }
+        public int SignalStrength { get; set; }
+        public decimal Snr { get; set; }
+        public int TransmissionIntervalMinutes { get; set; }
+        public bool SupportsValveControl { get; set; }
+        public bool SupportsTwoWayCommunication { get; set; }
+        public string? Notes { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/LoRaModels/LoRaAlert.cs
+++ b/AspNetCore8Test/Models/LoRaModels/LoRaAlert.cs
@@ -1,0 +1,19 @@
+namespace AspNetCore8Test.Models.LoRaModels
+{
+    public class LoRaAlert
+    {
+        public int Id { get; set; }
+        public int DeviceId { get; set; }
+        public string AlertType { get; set; } = string.Empty;
+        public string Severity { get; set; } = "Medium";
+        public string Title { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public string Status { get; set; } = "Active";
+        public DateTime? AcknowledgedAt { get; set; }
+        public string? AcknowledgedBy { get; set; }
+        public DateTime? ResolvedAt { get; set; }
+        public string? ResolvedBy { get; set; }
+        public string? ResolutionNotes { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/LoRaModels/LoRaDevice.cs
+++ b/AspNetCore8Test/Models/LoRaModels/LoRaDevice.cs
@@ -1,0 +1,27 @@
+namespace AspNetCore8Test.Models.LoRaModels
+{
+    public class LoRaDevice
+    {
+        public int Id { get; set; }
+        public string DeviceCode { get; set; } = string.Empty;
+        public string DeviceName { get; set; } = string.Empty;
+        public string MeterType { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public decimal BatteryLevel { get; set; }
+        public int SignalStrength { get; set; }
+        public decimal Snr { get; set; }
+        public string FirmwareVersion { get; set; } = string.Empty;
+        public string Status { get; set; } = "Active";
+        public DateTime InstallDate { get; set; } = DateTime.UtcNow.Date;
+        public DateTime LastCommunication { get; set; } = DateTime.UtcNow;
+        public int? GatewayId { get; set; }
+        public int TransmissionIntervalMinutes { get; set; }
+        public bool SupportsValveControl { get; set; }
+        public bool SupportsTwoWayCommunication { get; set; }
+        public decimal? LastReadingValue { get; set; }
+        public DateTime? LastReadingAt { get; set; }
+        public string? Notes { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/LoRaModels/LoRaGateway.cs
+++ b/AspNetCore8Test/Models/LoRaModels/LoRaGateway.cs
@@ -1,0 +1,22 @@
+namespace AspNetCore8Test.Models.LoRaModels
+{
+    public class LoRaGateway
+    {
+        public int Id { get; set; }
+        public string GatewayCode { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public string Status { get; set; } = "Online";
+        public DateTime LastHeartbeat { get; set; } = DateTime.UtcNow;
+        public DateTime InstalledDate { get; set; } = DateTime.UtcNow.Date;
+        public string FirmwareVersion { get; set; } = string.Empty;
+        public string ChannelPlan { get; set; } = string.Empty;
+        public string UplinkFrequency { get; set; } = string.Empty;
+        public string DownlinkFrequency { get; set; } = string.Empty;
+        public decimal CoverageRadiusKm { get; set; }
+        public string BackhaulType { get; set; } = string.Empty;
+        public double PacketForwardSuccessRate { get; set; }
+    }
+}

--- a/AspNetCore8Test/Models/LoRaModels/LoRaMeterReading.cs
+++ b/AspNetCore8Test/Models/LoRaModels/LoRaMeterReading.cs
@@ -1,0 +1,20 @@
+namespace AspNetCore8Test.Models.LoRaModels
+{
+    public class LoRaMeterReading
+    {
+        public int Id { get; set; }
+        public int DeviceId { get; set; }
+        public DateTime ReadingTime { get; set; }
+        public decimal Consumption { get; set; }
+        public decimal? Temperature { get; set; }
+        public decimal? BatteryLevel { get; set; }
+        public decimal? BatteryVoltage { get; set; }
+        public int? Rssi { get; set; }
+        public decimal? Snr { get; set; }
+        public decimal? PacketLossRate { get; set; }
+        public string? ValveStatus { get; set; }
+        public string? TamperStatus { get; set; }
+        public bool? IsConfirmed { get; set; }
+        public string DataRate { get; set; } = string.Empty;
+    }
+}

--- a/AspNetCore8Test/Program.cs
+++ b/AspNetCore8Test/Program.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using AspNetCore8Test.Models.DTOs;
 using AspNetCore8Test.Validators;
 using AspNetCore8Test.Services;
+using AspNetCore8Test.Services.LoRaServices;
 using AspNetCore8Test.Services.ParkServices;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -20,6 +21,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddScoped<IProductService, ProductService>();
 builder.Services.AddScoped<ApprovalService>();
 builder.Services.AddScoped<LibraryService>();
+builder.Services.AddScoped<ILoRaSystemService, LoRaSystemService>();
 
 // 註冊地政士系統服務
 builder.Services.AddScoped<AspNetCore8Test.Services.LandSurveyorServices.ICustomerService, 

--- a/AspNetCore8Test/Services/LoRaServices/LoRaSystemService.cs
+++ b/AspNetCore8Test/Services/LoRaServices/LoRaSystemService.cs
@@ -1,0 +1,940 @@
+using AspNetCore8Test.Models.DTOs.LoRaDTOs;
+using AspNetCore8Test.Models.LoRaModels;
+
+namespace AspNetCore8Test.Services.LoRaServices
+{
+    public interface ILoRaSystemService
+    {
+        Task<LoRaDashboardStatsDto> GetDashboardStatsAsync();
+        Task<IEnumerable<LoRaGatewayDto>> GetGatewaysAsync();
+        Task<IEnumerable<LoRaDeviceDto>> GetDevicesAsync(string? status = null, string? search = null, int? gatewayId = null);
+        Task<LoRaDeviceDto?> GetDeviceByIdAsync(int id);
+        Task<LoRaDeviceDto> AddDeviceAsync(CreateLoRaDeviceDto dto);
+        Task<bool> UpdateDeviceAsync(int id, UpdateLoRaDeviceDto dto);
+        Task<bool> RemoveDeviceAsync(int id);
+        Task<IEnumerable<LoRaMeterReadingDto>> GetLatestReadingsAsync(int? deviceId = null, int limit = 20);
+        Task<IEnumerable<LoRaMeterReadingDto>> GetDeviceReadingsAsync(int deviceId, DateTime? from = null, DateTime? to = null);
+        Task<LoRaMeterReadingDto> AddMeterReadingAsync(CreateLoRaMeterReadingDto dto);
+        Task<IEnumerable<LoRaAlertDto>> GetAlertsAsync(string? status = null, int? deviceId = null);
+        Task<LoRaAlertDto> CreateAlertAsync(CreateLoRaAlertDto dto);
+        Task<bool> UpdateAlertStatusAsync(int alertId, UpdateLoRaAlertStatusDto dto);
+    }
+
+    public class LoRaSystemService : ILoRaSystemService
+    {
+        private static readonly List<LoRaGateway> _gateways = new();
+        private static readonly List<LoRaDevice> _devices = new();
+        private static readonly List<LoRaMeterReading> _readings = new();
+        private static readonly List<LoRaAlert> _alerts = new();
+
+        private static int _nextGatewayId = 1;
+        private static int _nextDeviceId = 1;
+        private static int _nextReadingId = 1;
+        private static int _nextAlertId = 1;
+
+        private readonly object _lock = new();
+
+        public LoRaSystemService()
+        {
+            if (!_gateways.Any())
+            {
+                lock (_lock)
+                {
+                    if (!_gateways.Any())
+                    {
+                        InitializeSampleData();
+                    }
+                }
+            }
+        }
+
+        public Task<LoRaDashboardStatsDto> GetDashboardStatsAsync()
+        {
+            lock (_lock)
+            {
+                var devices = _devices.ToList();
+                var gateways = _gateways.ToList();
+                var alerts = _alerts.ToList();
+                var readings = _readings.ToList();
+                var now = DateTime.UtcNow;
+
+                var stats = new LoRaDashboardStatsDto
+                {
+                    TotalDevices = devices.Count,
+                    ActiveDevices = devices.Count(d => string.Equals(d.Status, "Active", StringComparison.OrdinalIgnoreCase)),
+                    MaintenanceDevices = devices.Count(d => string.Equals(d.Status, "Maintenance", StringComparison.OrdinalIgnoreCase)),
+                    OfflineDevices = devices.Count(d => string.Equals(d.Status, "Offline", StringComparison.OrdinalIgnoreCase)),
+                    TotalGateways = gateways.Count,
+                    GatewayOnline = gateways.Count(g => string.Equals(g.Status, "Online", StringComparison.OrdinalIgnoreCase)),
+                    GatewayOffline = gateways.Count(g => !string.Equals(g.Status, "Online", StringComparison.OrdinalIgnoreCase)),
+                    AverageBatteryLevel = devices.Any() ? Math.Round((double)devices.Average(d => d.BatteryLevel), 1) : 0,
+                    AverageSignalStrength = devices.Any() ? Math.Round(devices.Average(d => d.SignalStrength), 1) : 0,
+                    ActiveAlerts = alerts.Count(a => string.Equals(a.Status, "Active", StringComparison.OrdinalIgnoreCase)),
+                    DailyReadings = readings.Count(r => r.ReadingTime.Date == now.Date),
+                    MonthlyReadings = readings.Count(r => r.ReadingTime >= new DateTime(now.Year, now.Month, 1))
+                };
+
+                return Task.FromResult(stats);
+            }
+        }
+
+        public Task<IEnumerable<LoRaGatewayDto>> GetGatewaysAsync()
+        {
+            lock (_lock)
+            {
+                var result = _gateways
+                    .Select(MapToGatewayDto)
+                    .OrderByDescending(g => g.LastHeartbeat)
+                    .ToList()
+                    .AsEnumerable();
+
+                return Task.FromResult(result);
+            }
+        }
+
+        public Task<IEnumerable<LoRaDeviceDto>> GetDevicesAsync(string? status = null, string? search = null, int? gatewayId = null)
+        {
+            lock (_lock)
+            {
+                var query = _devices.AsEnumerable();
+
+                if (!string.IsNullOrWhiteSpace(status))
+                {
+                    query = query.Where(d => string.Equals(d.Status, status, StringComparison.OrdinalIgnoreCase));
+                }
+
+                if (!string.IsNullOrWhiteSpace(search))
+                {
+                    query = query.Where(d =>
+                        d.DeviceName.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        d.DeviceCode.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        d.Location.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        d.MeterType.Contains(search, StringComparison.OrdinalIgnoreCase));
+                }
+
+                if (gatewayId.HasValue)
+                {
+                    query = query.Where(d => d.GatewayId == gatewayId.Value);
+                }
+
+                var result = query
+                    .Select(MapToDeviceDto)
+                    .OrderByDescending(d => d.LastCommunication)
+                    .ToList()
+                    .AsEnumerable();
+
+                return Task.FromResult(result);
+            }
+        }
+
+        public Task<LoRaDeviceDto?> GetDeviceByIdAsync(int id)
+        {
+            lock (_lock)
+            {
+                var device = _devices.FirstOrDefault(d => d.Id == id);
+                return Task.FromResult(device != null ? MapToDeviceDto(device) : null);
+            }
+        }
+
+        public Task<LoRaDeviceDto> AddDeviceAsync(CreateLoRaDeviceDto dto)
+        {
+            lock (_lock)
+            {
+                var device = new LoRaDevice
+                {
+                    Id = _nextDeviceId++,
+                    DeviceCode = dto.DeviceCode,
+                    DeviceName = dto.DeviceName,
+                    MeterType = dto.MeterType,
+                    Location = dto.Location,
+                    Latitude = dto.Latitude,
+                    Longitude = dto.Longitude,
+                    GatewayId = dto.GatewayId,
+                    Status = string.IsNullOrWhiteSpace(dto.Status) ? "Active" : dto.Status!,
+                    InstallDate = dto.InstallDate ?? DateTime.UtcNow.Date,
+                    FirmwareVersion = string.IsNullOrWhiteSpace(dto.FirmwareVersion) ? "v1.0.0" : dto.FirmwareVersion!,
+                    BatteryLevel = dto.InitialBatteryLevel.HasValue ? Math.Clamp(dto.InitialBatteryLevel.Value, 0m, 100m) : 100m,
+                    SignalStrength = dto.InitialSignalStrength ?? -80,
+                    Snr = dto.InitialSnr ?? 8m,
+                    TransmissionIntervalMinutes = dto.TransmissionIntervalMinutes > 0 ? dto.TransmissionIntervalMinutes : 15,
+                    SupportsValveControl = dto.SupportsValveControl,
+                    SupportsTwoWayCommunication = dto.SupportsTwoWayCommunication,
+                    Notes = dto.Notes,
+                    LastCommunication = DateTime.UtcNow
+                };
+
+                _devices.Add(device);
+
+                return Task.FromResult(MapToDeviceDto(device));
+            }
+        }
+
+        public Task<bool> UpdateDeviceAsync(int id, UpdateLoRaDeviceDto dto)
+        {
+            lock (_lock)
+            {
+                var device = _devices.FirstOrDefault(d => d.Id == id);
+                if (device == null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                device.DeviceName = dto.DeviceName;
+                device.MeterType = dto.MeterType;
+                device.Location = dto.Location;
+                device.Latitude = dto.Latitude;
+                device.Longitude = dto.Longitude;
+                device.GatewayId = dto.GatewayId;
+                device.Status = dto.Status;
+                device.FirmwareVersion = dto.FirmwareVersion;
+                device.BatteryLevel = Math.Clamp(dto.BatteryLevel, 0m, 100m);
+                device.SignalStrength = dto.SignalStrength;
+                device.Snr = dto.Snr;
+                device.TransmissionIntervalMinutes = dto.TransmissionIntervalMinutes;
+                device.SupportsValveControl = dto.SupportsValveControl;
+                device.SupportsTwoWayCommunication = dto.SupportsTwoWayCommunication;
+                device.Notes = dto.Notes;
+                device.LastCommunication = DateTime.UtcNow;
+
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<bool> RemoveDeviceAsync(int id)
+        {
+            lock (_lock)
+            {
+                var device = _devices.FirstOrDefault(d => d.Id == id);
+                if (device == null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                _devices.Remove(device);
+                _readings.RemoveAll(r => r.DeviceId == id);
+                _alerts.RemoveAll(a => a.DeviceId == id);
+
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<IEnumerable<LoRaMeterReadingDto>> GetLatestReadingsAsync(int? deviceId = null, int limit = 20)
+        {
+            lock (_lock)
+            {
+                var query = _readings.AsEnumerable();
+
+                if (deviceId.HasValue)
+                {
+                    query = query.Where(r => r.DeviceId == deviceId.Value);
+                }
+
+                var result = query
+                    .OrderByDescending(r => r.ReadingTime)
+                    .Take(limit)
+                    .Select(MapToMeterReadingDto)
+                    .ToList()
+                    .AsEnumerable();
+
+                return Task.FromResult(result);
+            }
+        }
+
+        public Task<IEnumerable<LoRaMeterReadingDto>> GetDeviceReadingsAsync(int deviceId, DateTime? from = null, DateTime? to = null)
+        {
+            lock (_lock)
+            {
+                var query = _readings.Where(r => r.DeviceId == deviceId);
+
+                if (from.HasValue)
+                {
+                    query = query.Where(r => r.ReadingTime >= from.Value);
+                }
+
+                if (to.HasValue)
+                {
+                    query = query.Where(r => r.ReadingTime <= to.Value);
+                }
+
+                var result = query
+                    .OrderByDescending(r => r.ReadingTime)
+                    .Select(MapToMeterReadingDto)
+                    .ToList()
+                    .AsEnumerable();
+
+                return Task.FromResult(result);
+            }
+        }
+
+        public Task<LoRaMeterReadingDto> AddMeterReadingAsync(CreateLoRaMeterReadingDto dto)
+        {
+            lock (_lock)
+            {
+                var device = _devices.FirstOrDefault(d => d.Id == dto.DeviceId)
+                    ?? throw new ArgumentException($"找不到編號為 {dto.DeviceId} 的 LoRa 設備");
+
+                var reading = new LoRaMeterReading
+                {
+                    Id = _nextReadingId++,
+                    DeviceId = device.Id,
+                    ReadingTime = dto.ReadingTime ?? DateTime.UtcNow,
+                    Consumption = dto.Consumption,
+                    Temperature = dto.Temperature,
+                    BatteryLevel = dto.BatteryLevel,
+                    BatteryVoltage = dto.BatteryVoltage,
+                    Rssi = dto.Rssi,
+                    Snr = dto.Snr,
+                    PacketLossRate = dto.PacketLossRate,
+                    ValveStatus = dto.ValveStatus,
+                    TamperStatus = dto.TamperStatus,
+                    IsConfirmed = dto.IsConfirmed,
+                    DataRate = string.IsNullOrWhiteSpace(dto.DataRate) ? "DR2" : dto.DataRate
+                };
+
+                _readings.Add(reading);
+
+                device.LastReadingValue = reading.Consumption;
+                device.LastReadingAt = reading.ReadingTime;
+                device.LastCommunication = reading.ReadingTime;
+
+                if (reading.BatteryLevel.HasValue)
+                {
+                    device.BatteryLevel = Math.Clamp(reading.BatteryLevel.Value, 0m, 100m);
+                }
+
+                if (reading.Rssi.HasValue)
+                {
+                    device.SignalStrength = reading.Rssi.Value;
+                }
+
+                if (reading.Snr.HasValue)
+                {
+                    device.Snr = reading.Snr.Value;
+                }
+
+                EvaluateReadingForAlerts(device, reading);
+
+                return Task.FromResult(MapToMeterReadingDto(reading));
+            }
+        }
+
+        public Task<IEnumerable<LoRaAlertDto>> GetAlertsAsync(string? status = null, int? deviceId = null)
+        {
+            lock (_lock)
+            {
+                var query = _alerts.AsEnumerable();
+
+                if (!string.IsNullOrWhiteSpace(status))
+                {
+                    query = query.Where(a => string.Equals(a.Status, status, StringComparison.OrdinalIgnoreCase));
+                }
+
+                if (deviceId.HasValue)
+                {
+                    query = query.Where(a => a.DeviceId == deviceId.Value);
+                }
+
+                var result = query
+                    .OrderByDescending(a => a.CreatedAt)
+                    .Select(MapToAlertDto)
+                    .ToList()
+                    .AsEnumerable();
+
+                return Task.FromResult(result);
+            }
+        }
+
+        public Task<LoRaAlertDto> CreateAlertAsync(CreateLoRaAlertDto dto)
+        {
+            lock (_lock)
+            {
+                var device = _devices.FirstOrDefault(d => d.Id == dto.DeviceId)
+                    ?? throw new ArgumentException($"找不到編號為 {dto.DeviceId} 的 LoRa 設備");
+
+                var alert = new LoRaAlert
+                {
+                    Id = _nextAlertId++,
+                    DeviceId = device.Id,
+                    AlertType = dto.AlertType,
+                    Severity = dto.Severity,
+                    Title = string.IsNullOrWhiteSpace(dto.Title) ? dto.AlertType : dto.Title,
+                    Message = dto.Message,
+                    CreatedAt = DateTime.UtcNow,
+                    Status = "Active"
+                };
+
+                _alerts.Add(alert);
+
+                return Task.FromResult(MapToAlertDto(alert));
+            }
+        }
+
+        public Task<bool> UpdateAlertStatusAsync(int alertId, UpdateLoRaAlertStatusDto dto)
+        {
+            lock (_lock)
+            {
+                var alert = _alerts.FirstOrDefault(a => a.Id == alertId);
+                if (alert == null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                alert.Status = dto.Status;
+
+                if (string.Equals(dto.Status, "Acknowledged", StringComparison.OrdinalIgnoreCase))
+                {
+                    alert.AcknowledgedAt = DateTime.UtcNow;
+                    alert.AcknowledgedBy = string.IsNullOrWhiteSpace(dto.ResolvedBy) ? "系統" : dto.ResolvedBy;
+                }
+
+                if (string.Equals(dto.Status, "Resolved", StringComparison.OrdinalIgnoreCase))
+                {
+                    alert.ResolvedAt = DateTime.UtcNow;
+                    alert.ResolvedBy = string.IsNullOrWhiteSpace(dto.ResolvedBy) ? "系統" : dto.ResolvedBy;
+                    alert.ResolutionNotes = dto.ResolutionNotes;
+                }
+
+                return Task.FromResult(true);
+            }
+        }
+
+        private void InitializeSampleData()
+        {
+            var gatewayNorth = new LoRaGateway
+            {
+                Id = _nextGatewayId++,
+                GatewayCode = "GW-NORTH-001",
+                Name = "內湖智慧水表閘道器",
+                Location = "台北市內湖區內湖路一段 300 號",
+                Latitude = 25.0806,
+                Longitude = 121.5755,
+                Status = "Online",
+                LastHeartbeat = DateTime.UtcNow.AddMinutes(-2),
+                InstalledDate = DateTime.UtcNow.AddMonths(-10),
+                FirmwareVersion = "v2.4.3",
+                ChannelPlan = "AS923-1",
+                UplinkFrequency = "923.2 MHz",
+                DownlinkFrequency = "923.2 MHz",
+                CoverageRadiusKm = 2.3m,
+                BackhaulType = "4G LTE",
+                PacketForwardSuccessRate = 98.7
+            };
+
+            var gatewayCentral = new LoRaGateway
+            {
+                Id = _nextGatewayId++,
+                GatewayCode = "GW-CENTRAL-002",
+                Name = "中山區集中器",
+                Location = "台北市中山區南京東路三段 120 號",
+                Latitude = 25.0514,
+                Longitude = 121.5438,
+                Status = "Online",
+                LastHeartbeat = DateTime.UtcNow.AddMinutes(-5),
+                InstalledDate = DateTime.UtcNow.AddMonths(-14),
+                FirmwareVersion = "v2.3.9",
+                ChannelPlan = "AS923-1",
+                UplinkFrequency = "923.4 MHz",
+                DownlinkFrequency = "923.4 MHz",
+                CoverageRadiusKm = 2.8m,
+                BackhaulType = "光纖",
+                PacketForwardSuccessRate = 97.9
+            };
+
+            var gatewaySouth = new LoRaGateway
+            {
+                Id = _nextGatewayId++,
+                GatewayCode = "GW-SOUTH-003",
+                Name = "新店南區閘道器",
+                Location = "新北市新店區北宜路二段 200 號",
+                Latitude = 24.9598,
+                Longitude = 121.5386,
+                Status = "Maintenance",
+                LastHeartbeat = DateTime.UtcNow.AddMinutes(-32),
+                InstalledDate = DateTime.UtcNow.AddMonths(-20),
+                FirmwareVersion = "v2.1.4",
+                ChannelPlan = "AS923-1",
+                UplinkFrequency = "923.0 MHz",
+                DownlinkFrequency = "923.0 MHz",
+                CoverageRadiusKm = 3.1m,
+                BackhaulType = "微波",
+                PacketForwardSuccessRate = 95.2
+            };
+
+            _gateways.AddRange(new[] { gatewayNorth, gatewayCentral, gatewaySouth });
+
+            var deviceA = new LoRaDevice
+            {
+                Id = _nextDeviceId++,
+                DeviceCode = "LORA-WM-0001",
+                DeviceName = "內湖 1 號智慧水表",
+                MeterType = "Water",
+                Location = "內湖區康寧路三段 200 巷 12 號",
+                Latitude = 25.0839,
+                Longitude = 121.6112,
+                GatewayId = gatewayNorth.Id,
+                Status = "Active",
+                InstallDate = DateTime.UtcNow.AddMonths(-11),
+                FirmwareVersion = "v1.2.5",
+                BatteryLevel = 86.5m,
+                SignalStrength = -84,
+                Snr = 9.4m,
+                TransmissionIntervalMinutes = 30,
+                SupportsValveControl = true,
+                SupportsTwoWayCommunication = true,
+                Notes = "地下室安裝，具備閥控功能",
+                LastCommunication = DateTime.UtcNow.AddMinutes(-8),
+                LastReadingValue = 128.6m,
+                LastReadingAt = DateTime.UtcNow.AddHours(-3)
+            };
+
+            var deviceB = new LoRaDevice
+            {
+                Id = _nextDeviceId++,
+                DeviceCode = "LORA-GM-0205",
+                DeviceName = "民生社區瓦斯表",
+                MeterType = "Gas",
+                Location = "松山區民生東路五段 250 巷 18 弄 5 號",
+                Latitude = 25.0607,
+                Longitude = 121.5579,
+                GatewayId = gatewayCentral.Id,
+                Status = "Active",
+                InstallDate = DateTime.UtcNow.AddMonths(-7),
+                FirmwareVersion = "v1.3.1",
+                BatteryLevel = 72.3m,
+                SignalStrength = -92,
+                Snr = 7.6m,
+                TransmissionIntervalMinutes = 20,
+                SupportsValveControl = false,
+                SupportsTwoWayCommunication = true,
+                Notes = "一般戶，每日 72 筆回傳",
+                LastCommunication = DateTime.UtcNow.AddMinutes(-12),
+                LastReadingValue = 412.2m,
+                LastReadingAt = DateTime.UtcNow.AddHours(-2)
+            };
+
+            var deviceC = new LoRaDevice
+            {
+                Id = _nextDeviceId++,
+                DeviceCode = "LORA-EM-1052",
+                DeviceName = "新店電力抄表",
+                MeterType = "Electric",
+                Location = "新店區安和路一段 230 號",
+                Latitude = 24.9673,
+                Longitude = 121.5409,
+                GatewayId = gatewaySouth.Id,
+                Status = "Maintenance",
+                InstallDate = DateTime.UtcNow.AddMonths(-18),
+                FirmwareVersion = "v1.1.8",
+                BatteryLevel = 54.9m,
+                SignalStrength = -110,
+                Snr = 4.2m,
+                TransmissionIntervalMinutes = 60,
+                SupportsValveControl = false,
+                SupportsTwoWayCommunication = false,
+                Notes = "施工現場，訊號偏弱",
+                LastCommunication = DateTime.UtcNow.AddMinutes(-35),
+                LastReadingValue = 9824.4m,
+                LastReadingAt = DateTime.UtcNow.AddHours(-5)
+            };
+
+            var deviceD = new LoRaDevice
+            {
+                Id = _nextDeviceId++,
+                DeviceCode = "LORA-WM-0310",
+                DeviceName = "士林市場水表",
+                MeterType = "Water",
+                Location = "士林區大南路 84 號",
+                Latitude = 25.0914,
+                Longitude = 121.5240,
+                GatewayId = gatewayCentral.Id,
+                Status = "Offline",
+                InstallDate = DateTime.UtcNow.AddMonths(-24),
+                FirmwareVersion = "v1.0.9",
+                BatteryLevel = 18.1m,
+                SignalStrength = -118,
+                Snr = 0.3m,
+                TransmissionIntervalMinutes = 45,
+                SupportsValveControl = true,
+                SupportsTwoWayCommunication = true,
+                Notes = "需安排現場巡檢",
+                LastCommunication = DateTime.UtcNow.AddHours(-12),
+                LastReadingValue = 256.7m,
+                LastReadingAt = DateTime.UtcNow.AddHours(-12)
+            };
+
+            _devices.AddRange(new[] { deviceA, deviceB, deviceC, deviceD });
+
+            AddSampleReadings(deviceA, new List<LoRaMeterReading>
+            {
+                new LoRaMeterReading
+                {
+                    DeviceId = deviceA.Id,
+                    ReadingTime = DateTime.UtcNow.AddHours(-18),
+                    Consumption = 120.4m,
+                    Temperature = 24.6m,
+                    BatteryLevel = 88.2m,
+                    BatteryVoltage = 3.64m,
+                    Rssi = -86,
+                    Snr = 9.8m,
+                    PacketLossRate = 0.2m,
+                    ValveStatus = "Open",
+                    TamperStatus = "Normal",
+                    IsConfirmed = true,
+                    DataRate = "DR2"
+                },
+                new LoRaMeterReading
+                {
+                    DeviceId = deviceA.Id,
+                    ReadingTime = DateTime.UtcNow.AddHours(-6),
+                    Consumption = 128.6m,
+                    Temperature = 25.1m,
+                    BatteryLevel = 86.5m,
+                    BatteryVoltage = 3.61m,
+                    Rssi = -84,
+                    Snr = 9.4m,
+                    PacketLossRate = 0.3m,
+                    ValveStatus = "Open",
+                    TamperStatus = "Normal",
+                    IsConfirmed = true,
+                    DataRate = "DR3"
+                }
+            });
+
+            AddSampleReadings(deviceB, new List<LoRaMeterReading>
+            {
+                new LoRaMeterReading
+                {
+                    DeviceId = deviceB.Id,
+                    ReadingTime = DateTime.UtcNow.AddHours(-10),
+                    Consumption = 405.9m,
+                    Temperature = 26.2m,
+                    BatteryLevel = 74.1m,
+                    BatteryVoltage = 3.59m,
+                    Rssi = -95,
+                    Snr = 7.1m,
+                    PacketLossRate = 0.6m,
+                    ValveStatus = "N/A",
+                    TamperStatus = "Normal",
+                    IsConfirmed = true,
+                    DataRate = "DR2"
+                },
+                new LoRaMeterReading
+                {
+                    DeviceId = deviceB.Id,
+                    ReadingTime = DateTime.UtcNow.AddHours(-2),
+                    Consumption = 412.2m,
+                    Temperature = 27.0m,
+                    BatteryLevel = 72.3m,
+                    BatteryVoltage = 3.56m,
+                    Rssi = -92,
+                    Snr = 7.6m,
+                    PacketLossRate = 0.4m,
+                    ValveStatus = "N/A",
+                    TamperStatus = "Normal",
+                    IsConfirmed = true,
+                    DataRate = "DR3"
+                }
+            });
+
+            AddSampleReadings(deviceC, new List<LoRaMeterReading>
+            {
+                new LoRaMeterReading
+                {
+                    DeviceId = deviceC.Id,
+                    ReadingTime = DateTime.UtcNow.AddHours(-13),
+                    Consumption = 9788.9m,
+                    Temperature = 30.4m,
+                    BatteryLevel = 56.2m,
+                    BatteryVoltage = 3.42m,
+                    Rssi = -112,
+                    Snr = 4.6m,
+                    PacketLossRate = 2.5m,
+                    ValveStatus = "N/A",
+                    TamperStatus = "Normal",
+                    IsConfirmed = true,
+                    DataRate = "DR1"
+                },
+                new LoRaMeterReading
+                {
+                    DeviceId = deviceC.Id,
+                    ReadingTime = DateTime.UtcNow.AddHours(-5),
+                    Consumption = 9824.4m,
+                    Temperature = 31.1m,
+                    BatteryLevel = 54.9m,
+                    BatteryVoltage = 3.39m,
+                    Rssi = -110,
+                    Snr = 4.2m,
+                    PacketLossRate = 3.1m,
+                    ValveStatus = "N/A",
+                    TamperStatus = "DoorOpen",
+                    IsConfirmed = false,
+                    DataRate = "DR1"
+                }
+            });
+
+            AddSampleReadings(deviceD, new List<LoRaMeterReading>
+            {
+                new LoRaMeterReading
+                {
+                    DeviceId = deviceD.Id,
+                    ReadingTime = DateTime.UtcNow.AddHours(-26),
+                    Consumption = 248.1m,
+                    Temperature = 23.5m,
+                    BatteryLevel = 23.4m,
+                    BatteryVoltage = 3.22m,
+                    Rssi = -118,
+                    Snr = 1.4m,
+                    PacketLossRate = 8.2m,
+                    ValveStatus = "Closed",
+                    TamperStatus = "Normal",
+                    IsConfirmed = false,
+                    DataRate = "DR1"
+                },
+                new LoRaMeterReading
+                {
+                    DeviceId = deviceD.Id,
+                    ReadingTime = DateTime.UtcNow.AddHours(-12),
+                    Consumption = 256.7m,
+                    Temperature = 24.0m,
+                    BatteryLevel = 18.1m,
+                    BatteryVoltage = 3.14m,
+                    Rssi = -122,
+                    Snr = 0.3m,
+                    PacketLossRate = 12.4m,
+                    ValveStatus = "Closed",
+                    TamperStatus = "Tilt",
+                    IsConfirmed = false,
+                    DataRate = "DR0"
+                }
+            });
+
+            var alertLowBattery = new LoRaAlert
+            {
+                Id = _nextAlertId++,
+                DeviceId = deviceD.Id,
+                AlertType = "Battery",
+                Severity = "High",
+                Title = "電池電量低於 20%",
+                Message = "目前電池僅剩 18%，請安排更換。",
+                CreatedAt = DateTime.UtcNow.AddHours(-11),
+                Status = "Active"
+            };
+
+            var alertTamper = new LoRaAlert
+            {
+                Id = _nextAlertId++,
+                DeviceId = deviceC.Id,
+                AlertType = "Tamper",
+                Severity = "Medium",
+                Title = "疑似箱門開啟",
+                Message = "設備回報 Tamper 狀態為 DoorOpen，請派員確認。",
+                CreatedAt = DateTime.UtcNow.AddHours(-4),
+                Status = "Acknowledged",
+                AcknowledgedAt = DateTime.UtcNow.AddHours(-3),
+                AcknowledgedBy = "巡檢系統"
+            };
+
+            var alertSignal = new LoRaAlert
+            {
+                Id = _nextAlertId++,
+                DeviceId = deviceC.Id,
+                AlertType = "Signal",
+                Severity = "Medium",
+                Title = "訊號強度偏弱",
+                Message = "最近 24 小時平均 RSSI -111 dBm。",
+                CreatedAt = DateTime.UtcNow.AddHours(-1),
+                Status = "Active"
+            };
+
+            _alerts.AddRange(new[] { alertLowBattery, alertTamper, alertSignal });
+        }
+
+        private void AddSampleReadings(LoRaDevice device, IEnumerable<LoRaMeterReading> readings)
+        {
+            foreach (var reading in readings)
+            {
+                reading.Id = _nextReadingId++;
+                _readings.Add(reading);
+
+                device.LastReadingValue = reading.Consumption;
+                device.LastReadingAt = reading.ReadingTime;
+
+                if (reading.BatteryLevel.HasValue)
+                {
+                    device.BatteryLevel = Math.Clamp(reading.BatteryLevel.Value, 0m, 100m);
+                }
+
+                if (reading.Rssi.HasValue)
+                {
+                    device.SignalStrength = reading.Rssi.Value;
+                }
+
+                if (reading.Snr.HasValue)
+                {
+                    device.Snr = reading.Snr.Value;
+                }
+
+                if (device.LastCommunication < reading.ReadingTime)
+                {
+                    device.LastCommunication = reading.ReadingTime;
+                }
+            }
+        }
+
+        private void EvaluateReadingForAlerts(LoRaDevice device, LoRaMeterReading reading)
+        {
+            if (reading.BatteryLevel.HasValue && reading.BatteryLevel.Value < 20m)
+            {
+                _alerts.Add(new LoRaAlert
+                {
+                    Id = _nextAlertId++,
+                    DeviceId = device.Id,
+                    AlertType = "Battery",
+                    Severity = "High",
+                    Title = "電池電量不足",
+                    Message = $"電池電量降至 {reading.BatteryLevel:0.0}%，請安排更換。",
+                    CreatedAt = DateTime.UtcNow,
+                    Status = "Active"
+                });
+            }
+
+            if (reading.Rssi.HasValue && reading.Rssi.Value < -115)
+            {
+                _alerts.Add(new LoRaAlert
+                {
+                    Id = _nextAlertId++,
+                    DeviceId = device.Id,
+                    AlertType = "Signal",
+                    Severity = "Medium",
+                    Title = "訊號過低",
+                    Message = $"目前 RSSI 為 {reading.Rssi} dBm，需檢查天線或遮蔽物。",
+                    CreatedAt = DateTime.UtcNow,
+                    Status = "Active"
+                });
+            }
+
+            if (reading.PacketLossRate.HasValue && reading.PacketLossRate.Value > 10m)
+            {
+                _alerts.Add(new LoRaAlert
+                {
+                    Id = _nextAlertId++,
+                    DeviceId = device.Id,
+                    AlertType = "Network",
+                    Severity = "Medium",
+                    Title = "封包遺失率偏高",
+                    Message = $"偵測到封包遺失率 {reading.PacketLossRate:0.0}% ，請檢查通訊品質。",
+                    CreatedAt = DateTime.UtcNow,
+                    Status = "Active"
+                });
+            }
+        }
+
+        private LoRaDeviceDto MapToDeviceDto(LoRaDevice device)
+        {
+            var gateway = device.GatewayId.HasValue
+                ? _gateways.FirstOrDefault(g => g.Id == device.GatewayId.Value)
+                : null;
+
+            return new LoRaDeviceDto
+            {
+                Id = device.Id,
+                DeviceCode = device.DeviceCode,
+                DeviceName = device.DeviceName,
+                MeterType = device.MeterType,
+                Location = device.Location,
+                Latitude = device.Latitude,
+                Longitude = device.Longitude,
+                BatteryLevel = device.BatteryLevel,
+                SignalStrength = device.SignalStrength,
+                Snr = device.Snr,
+                FirmwareVersion = device.FirmwareVersion,
+                Status = device.Status,
+                InstallDate = device.InstallDate,
+                LastCommunication = device.LastCommunication,
+                GatewayId = device.GatewayId,
+                GatewayName = gateway?.Name,
+                TransmissionIntervalMinutes = device.TransmissionIntervalMinutes,
+                SupportsValveControl = device.SupportsValveControl,
+                SupportsTwoWayCommunication = device.SupportsTwoWayCommunication,
+                LastReadingValue = device.LastReadingValue,
+                LastReadingAt = device.LastReadingAt,
+                Notes = device.Notes
+            };
+        }
+
+        private LoRaGatewayDto MapToGatewayDto(LoRaGateway gateway)
+        {
+            var connectedDevices = _devices.Count(d => d.GatewayId == gateway.Id);
+
+            return new LoRaGatewayDto
+            {
+                Id = gateway.Id,
+                GatewayCode = gateway.GatewayCode,
+                Name = gateway.Name,
+                Location = gateway.Location,
+                Latitude = gateway.Latitude,
+                Longitude = gateway.Longitude,
+                Status = gateway.Status,
+                LastHeartbeat = gateway.LastHeartbeat,
+                InstalledDate = gateway.InstalledDate,
+                FirmwareVersion = gateway.FirmwareVersion,
+                ChannelPlan = gateway.ChannelPlan,
+                UplinkFrequency = gateway.UplinkFrequency,
+                DownlinkFrequency = gateway.DownlinkFrequency,
+                CoverageRadiusKm = gateway.CoverageRadiusKm,
+                BackhaulType = gateway.BackhaulType,
+                PacketForwardSuccessRate = gateway.PacketForwardSuccessRate,
+                ConnectedDevices = connectedDevices
+            };
+        }
+
+        private LoRaMeterReadingDto MapToMeterReadingDto(LoRaMeterReading reading)
+        {
+            var device = _devices.FirstOrDefault(d => d.Id == reading.DeviceId);
+
+            return new LoRaMeterReadingDto
+            {
+                Id = reading.Id,
+                DeviceId = reading.DeviceId,
+                DeviceCode = device?.DeviceCode ?? string.Empty,
+                DeviceName = device?.DeviceName ?? string.Empty,
+                ReadingTime = reading.ReadingTime,
+                Consumption = reading.Consumption,
+                Temperature = reading.Temperature,
+                BatteryLevel = reading.BatteryLevel,
+                BatteryVoltage = reading.BatteryVoltage,
+                Rssi = reading.Rssi,
+                Snr = reading.Snr,
+                PacketLossRate = reading.PacketLossRate,
+                ValveStatus = reading.ValveStatus,
+                TamperStatus = reading.TamperStatus,
+                IsConfirmed = reading.IsConfirmed,
+                DataRate = reading.DataRate
+            };
+        }
+
+        private LoRaAlertDto MapToAlertDto(LoRaAlert alert)
+        {
+            var device = _devices.FirstOrDefault(d => d.Id == alert.DeviceId);
+
+            return new LoRaAlertDto
+            {
+                Id = alert.Id,
+                DeviceId = alert.DeviceId,
+                DeviceCode = device?.DeviceCode ?? string.Empty,
+                DeviceName = device?.DeviceName ?? string.Empty,
+                AlertType = alert.AlertType,
+                Severity = alert.Severity,
+                Title = alert.Title,
+                Message = alert.Message,
+                CreatedAt = alert.CreatedAt,
+                Status = alert.Status,
+                AcknowledgedAt = alert.AcknowledgedAt,
+                AcknowledgedBy = alert.AcknowledgedBy,
+                ResolvedAt = alert.ResolvedAt,
+                ResolvedBy = alert.ResolvedBy,
+                ResolutionNotes = alert.ResolutionNotes
+            };
+        }
+    }
+}

--- a/AspNetCore8Test/Views/LoRa/Index.cshtml
+++ b/AspNetCore8Test/Views/LoRa/Index.cshtml
@@ -1,0 +1,795 @@
+@{
+    ViewData["Title"] = "微電腦無線抄表 LoRa 系統";
+}
+
+@section Styles {
+    <style>
+        .lora-card-icon {
+            width: 48px;
+            height: 48px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 12px;
+            font-size: 1.25rem;
+        }
+
+        .lora-status-offline {
+            background-color: rgba(220, 53, 69, 0.1);
+            color: #dc3545;
+        }
+
+        .lora-status-online {
+            background-color: rgba(25, 135, 84, 0.12);
+            color: #198754;
+        }
+
+        .lora-status-maintenance {
+            background-color: rgba(255, 193, 7, 0.15);
+            color: #856404;
+        }
+
+        .list-group-item + .list-group-item {
+            border-top-width: 0;
+        }
+
+        .table-responsive {
+            overflow-x: auto;
+        }
+    </style>
+}
+
+<div class="container-fluid">
+    <div class="row mb-4">
+        <div class="col-12 d-flex justify-content-between align-items-start flex-wrap gap-3">
+            <div>
+                <h2 class="mb-1"><i class="fas fa-satellite-dish text-primary me-2"></i>微電腦無線抄表 LoRa 系統</h2>
+                <p class="text-muted mb-0">即時掌握 LoRa 微電腦抄表網路狀態、閘道器與終端設備運行健康</p>
+            </div>
+            <div class="d-flex gap-2">
+                <button class="btn btn-outline-primary" id="refreshDataBtn">
+                    <i class="fas fa-sync-alt me-1"></i>重新整理資料
+                </button>
+                <button class="btn btn-success" id="simulateReadingBtn">
+                    <i class="fas fa-bolt me-1"></i>模擬即時抄表
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-3">
+        <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-center justify-content-between">
+                    <div>
+                        <h6 class="text-muted mb-1">總設備數</h6>
+                        <h3 class="mb-0" id="totalDevices">-</h3>
+                    </div>
+                    <div class="lora-card-icon bg-primary bg-opacity-10 text-primary">
+                        <i class="fas fa-microchip"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-center justify-content-between">
+                    <div>
+                        <h6 class="text-muted mb-1">正常運作</h6>
+                        <h3 class="mb-0" id="activeDevices">-</h3>
+                    </div>
+                    <div class="lora-card-icon bg-success bg-opacity-10 text-success">
+                        <i class="fas fa-signal"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-center justify-content-between">
+                    <div>
+                        <h6 class="text-muted mb-1">維護中</h6>
+                        <h3 class="mb-0" id="maintenanceDevices">-</h3>
+                    </div>
+                    <div class="lora-card-icon bg-warning bg-opacity-10 text-warning">
+                        <i class="fas fa-tools"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-center justify-content-between">
+                    <div>
+                        <h6 class="text-muted mb-1">離線設備</h6>
+                        <h3 class="mb-0" id="offlineDevices">-</h3>
+                    </div>
+                    <div class="lora-card-icon bg-danger bg-opacity-10 text-danger">
+                        <i class="fas fa-plug"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-4">
+        <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex flex-column justify-content-between">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <div>
+                            <h6 class="text-muted mb-1">活躍警報</h6>
+                            <h3 class="mb-0" id="activeAlerts">-</h3>
+                        </div>
+                        <div class="lora-card-icon bg-danger bg-opacity-10 text-danger">
+                            <i class="fas fa-bell"></i>
+                        </div>
+                    </div>
+                    <p class="text-muted small mb-0">今日抄表 <span class="fw-semibold" id="dailyReadings">-</span> 筆 / 本月 <span class="fw-semibold" id="monthlyReadings">-</span> 筆</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex justify-content-between align-items-center">
+                    <div>
+                        <h6 class="text-muted mb-1">平均電量</h6>
+                        <h3 class="mb-0" id="averageBattery">-</h3>
+                    </div>
+                    <div class="lora-card-icon bg-success bg-opacity-10 text-success">
+                        <i class="fas fa-battery-half"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex justify-content-between align-items-center">
+                    <div>
+                        <h6 class="text-muted mb-1">平均訊號 (RSSI)</h6>
+                        <h3 class="mb-0" id="averageSignal">-</h3>
+                    </div>
+                    <div class="lora-card-icon bg-info bg-opacity-10 text-info">
+                        <i class="fas fa-wave-square"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <div>
+                            <h6 class="text-muted mb-1">閘道器狀態</h6>
+                            <h3 class="mb-0" id="totalGateways">-</h3>
+                        </div>
+                        <div class="lora-card-icon bg-primary bg-opacity-10 text-primary">
+                            <i class="fas fa-broadcast-tower"></i>
+                        </div>
+                    </div>
+                    <div class="d-flex justify-content-between small text-muted">
+                        <span><i class="fas fa-circle text-success me-1"></i>在線 <span class="fw-semibold" id="gatewayOnline">-</span></span>
+                        <span><i class="fas fa-circle text-danger me-1"></i>離線 <span class="fw-semibold" id="gatewayOffline">-</span></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card border-0 shadow-sm mb-4">
+        <div class="card-header bg-white d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <div>
+                <h5 class="mb-0">LoRa 終端設備列表</h5>
+                <small class="text-muted">包含水表、瓦斯表、電表等微電腦無線抄表設備</small>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+                <div class="input-group" style="width: 260px;">
+                    <span class="input-group-text"><i class="fas fa-search"></i></span>
+                    <input type="text" class="form-control" id="searchInput" placeholder="搜尋設備名稱、編號或位置">
+                </div>
+                <select class="form-select" id="statusFilter" style="width: 160px;">
+                    <option value="">所有狀態</option>
+                    <option value="Active">正常運作</option>
+                    <option value="Maintenance">維護中</option>
+                    <option value="Offline">離線</option>
+                </select>
+                <select class="form-select" id="gatewayFilter" style="width: 200px;">
+                    <option value="">所有閘道器</option>
+                </select>
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table align-middle">
+                    <thead class="table-light">
+                        <tr>
+                            <th style="min-width: 220px;">設備資訊</th>
+                            <th>閘道器</th>
+                            <th>位置</th>
+                            <th style="min-width: 170px;">電量</th>
+                            <th>訊號 (dBm)</th>
+                            <th style="min-width: 180px;">最後讀表</th>
+                            <th>狀態</th>
+                            <th>功能</th>
+                        </tr>
+                    </thead>
+                    <tbody id="devicesTableBody">
+                        <tr>
+                            <td colspan="8" class="text-center text-muted">載入中...</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3 mb-4">
+        <div class="col-xl-8">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">最新抄表資料</h5>
+                    <small class="text-muted">最近 10 筆回傳資料</small>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>設備</th>
+                                    <th>讀表時間</th>
+                                    <th>讀值</th>
+                                    <th>電量</th>
+                                    <th>訊號</th>
+                                    <th>封包遺失率</th>
+                                </tr>
+                            </thead>
+                            <tbody id="latestReadingsBody">
+                                <tr>
+                                    <td colspan="6" class="text-center text-muted">尚無資料</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">警報通知</h5>
+                    <span class="badge bg-danger" id="alertCountBadge">0</span>
+                </div>
+                <div class="card-body">
+                    <div class="list-group" id="alertsContainer">
+                        <div class="list-group-item text-center text-muted">目前沒有活躍警報</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card border-0 shadow-sm mb-4">
+        <div class="card-header bg-white d-flex justify-content-between align-items-center">
+            <div>
+                <h5 class="mb-0">LoRa 閘道器佈建概況</h5>
+                <small class="text-muted">掌握閘道器健康狀況與連線設備數量</small>
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="row" id="gatewayCards">
+                <div class="col-12 text-center text-muted">載入中...</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        let cachedDevices = [];
+        let cachedGateways = [];
+
+        $(document).ready(function () {
+            loadAllData();
+
+            $('#searchInput').on('keyup', debounce(loadDevices, 400));
+            $('#statusFilter').on('change', loadDevices);
+            $('#gatewayFilter').on('change', loadDevices);
+
+            $('#refreshDataBtn').on('click', function () {
+                loadAllData();
+                showAlert('資料已重新整理', 'success');
+            });
+
+            $('#simulateReadingBtn').on('click', simulateRandomReading);
+        });
+
+        function loadAllData() {
+            loadStats();
+            loadGateways();
+            loadDevices();
+            loadAlerts();
+            loadLatestReadings();
+        }
+
+        function loadStats() {
+            $.get('/api/lorasystem/stats')
+                .done(function (data) {
+                    $('#totalDevices').text(data.totalDevices ?? 0);
+                    $('#activeDevices').text(data.activeDevices ?? 0);
+                    $('#maintenanceDevices').text(data.maintenanceDevices ?? 0);
+                    $('#offlineDevices').text(data.offlineDevices ?? 0);
+                    $('#activeAlerts').text(data.activeAlerts ?? 0);
+
+                    if (data.averageBatteryLevel !== undefined && data.averageBatteryLevel !== null) {
+                        $('#averageBattery').text(data.averageBatteryLevel.toFixed(1) + '%');
+                    } else {
+                        $('#averageBattery').text('-');
+                    }
+
+                    if (data.averageSignalStrength !== undefined && data.averageSignalStrength !== null) {
+                        $('#averageSignal').text(data.averageSignalStrength.toFixed(1) + ' dBm');
+                    } else {
+                        $('#averageSignal').text('-');
+                    }
+
+                    $('#dailyReadings').text(data.dailyReadings ?? 0);
+                    $('#monthlyReadings').text(data.monthlyReadings ?? 0);
+                    $('#totalGateways').text(data.totalGateways ?? 0);
+                    $('#gatewayOnline').text(data.gatewayOnline ?? 0);
+                    $('#gatewayOffline').text(data.gatewayOffline ?? 0);
+                })
+                .fail(function () {
+                    showAlert('載入統計資訊失敗，請稍後再試', 'danger');
+                });
+        }
+
+        function loadGateways() {
+            $.get('/api/lorasystem/gateways')
+                .done(function (data) {
+                    cachedGateways = data || [];
+                    renderGatewayOptions(cachedGateways);
+                    renderGatewayCards(cachedGateways);
+                })
+                .fail(function () {
+                    showAlert('載入閘道器資料失敗', 'danger');
+                });
+        }
+
+        function loadDevices() {
+            const searchTerm = $('#searchInput').val();
+            const status = $('#statusFilter').val();
+            const gatewayId = $('#gatewayFilter').val();
+
+            const params = new URLSearchParams();
+            if (searchTerm) params.append('search', searchTerm);
+            if (status) params.append('status', status);
+            if (gatewayId) params.append('gatewayId', gatewayId);
+
+            let url = '/api/lorasystem/devices';
+            if (params.toString()) {
+                url += '?' + params.toString();
+            }
+
+            $('#devicesTableBody').html('<tr><td colspan="8" class="text-center text-muted">載入中...</td></tr>');
+
+            $.get(url)
+                .done(function (data) {
+                    cachedDevices = data || [];
+                    renderDevicesTable(cachedDevices);
+                })
+                .fail(function () {
+                    showAlert('載入設備資料失敗', 'danger');
+                });
+        }
+
+        function loadAlerts() {
+            $.get('/api/lorasystem/alerts', { status: 'Active' })
+                .done(function (data) {
+                    renderAlertList(data || []);
+                })
+                .fail(function () {
+                    showAlert('載入警報資料失敗', 'danger');
+                });
+        }
+
+        function loadLatestReadings() {
+            $.get('/api/lorasystem/readings/latest', { count: 10 })
+                .done(function (data) {
+                    renderLatestReadings(data || []);
+                })
+                .fail(function () {
+                    showAlert('載入抄表資料失敗', 'danger');
+                });
+        }
+
+        function renderGatewayOptions(gateways) {
+            const select = $('#gatewayFilter');
+            const selected = select.val();
+            select.empty();
+            select.append('<option value="">所有閘道器</option>');
+
+            gateways.forEach(function (gateway) {
+                select.append(`<option value="${gateway.id}">${gateway.name}</option>`);
+            });
+
+            if (selected) {
+                select.val(selected);
+            }
+        }
+
+        function renderGatewayCards(gateways) {
+            const container = $('#gatewayCards');
+            container.empty();
+
+            if (!gateways.length) {
+                container.append('<div class="col-12 text-center text-muted">目前沒有閘道器資料</div>');
+                return;
+            }
+
+            gateways.forEach(function (gateway) {
+                const statusBadge = getGatewayStatusBadge(gateway.status);
+                const heartbeat = formatDateTime(gateway.lastHeartbeat);
+                const successRate = gateway.packetForwardSuccessRate !== undefined && gateway.packetForwardSuccessRate !== null
+                    ? gateway.packetForwardSuccessRate.toFixed(1) + '%'
+                    : '-';
+
+                const card = `
+                    <div class="col-xxl-3 col-lg-4 col-md-6 mb-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex justify-content-between align-items-start mb-2">
+                                    <div>
+                                        <h6 class="mb-1">${gateway.name}</h6>
+                                        ${statusBadge}
+                                    </div>
+                                    <span class="badge bg-light text-muted">${gateway.gatewayCode || ''}</span>
+                                </div>
+                                <p class="text-muted small mb-2"><i class="fas fa-map-marker-alt text-danger me-1"></i>${gateway.location || '-'}</p>
+                                <div class="small text-muted mb-2"><i class="fas fa-clock me-1"></i>最後心跳：${heartbeat}</div>
+                                <div class="mt-auto">
+                                    <div class="d-flex justify-content-between small text-muted">
+                                        <span><i class="fas fa-network-wired me-1 text-primary"></i>${gateway.connectedDevices ?? 0} 台設備</span>
+                                        <span><i class="fas fa-chart-line me-1 text-success"></i>${successRate}</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>`;
+
+                container.append(card);
+            });
+        }
+
+        function renderDevicesTable(devices) {
+            const tbody = $('#devicesTableBody');
+            tbody.empty();
+
+            if (!devices.length) {
+                tbody.append('<tr><td colspan="8" class="text-center text-muted">目前沒有符合條件的設備資料</td></tr>');
+                return;
+            }
+
+            devices.forEach(function (device) {
+                const statusBadge = getDeviceStatusBadge(device.status);
+                const gatewayName = device.gatewayName || '-';
+                const unit = getMeterUnit(device.meterType);
+                const readingValue = device.lastReadingValue !== null && device.lastReadingValue !== undefined
+                    ? formatNumber(device.lastReadingValue, 1) + ' ' + unit
+                    : '-';
+                const readingTime = formatDateTime(device.lastReadingAt);
+                const batteryBar = renderBatteryBar(device.batteryLevel);
+                const signalBadge = renderSignalBadge(device.signalStrength);
+                const featureBadges = renderFeatureBadges(device);
+
+                const row = `
+                    <tr>
+                        <td>
+                            <div class="fw-semibold">${device.deviceName}</div>
+                            <div class="text-muted small">${device.deviceCode} ｜ ${device.meterType || '未分類'}</div>
+                        </td>
+                        <td>${gatewayName}</td>
+                        <td>
+                            <div>${device.location || '-'}</div>
+                            ${renderCoordinateBadge(device)}
+                        </td>
+                        <td>${batteryBar}</td>
+                        <td>${signalBadge}</td>
+                        <td>
+                            <div class="fw-semibold">${readingValue}</div>
+                            <div class="text-muted small">${readingTime}</div>
+                        </td>
+                        <td>${statusBadge}</td>
+                        <td>${featureBadges}</td>
+                    </tr>`;
+
+                tbody.append(row);
+            });
+        }
+
+        function renderLatestReadings(readings) {
+            const tbody = $('#latestReadingsBody');
+            tbody.empty();
+
+            if (!readings.length) {
+                tbody.append('<tr><td colspan="6" class="text-center text-muted">目前沒有抄表資料</td></tr>');
+                return;
+            }
+
+            readings.forEach(function (reading) {
+                const deviceInfo = `<div class="fw-semibold">${reading.deviceName}</div><div class="text-muted small">${reading.deviceCode}</div>`;
+                const value = formatNumber(reading.consumption, 1) + ' ' + getMeterUnitFromDevice(reading.deviceId);
+                const battery = reading.batteryLevel !== null && reading.batteryLevel !== undefined
+                    ? formatNumber(reading.batteryLevel, 1) + '%'
+                    : '-';
+                const rssi = reading.rssi !== null && reading.rssi !== undefined ? `${reading.rssi} dBm` : '-';
+                const packetLoss = reading.packetLossRate !== null && reading.packetLossRate !== undefined
+                    ? formatNumber(reading.packetLossRate, 1) + '%'
+                    : '-';
+
+                const row = `
+                    <tr>
+                        <td>${deviceInfo}</td>
+                        <td>${formatDateTime(reading.readingTime)}</td>
+                        <td>${value}</td>
+                        <td>${battery}</td>
+                        <td>${rssi}</td>
+                        <td>${packetLoss}</td>
+                    </tr>`;
+
+                tbody.append(row);
+            });
+        }
+
+        function renderAlertList(alerts) {
+            const container = $('#alertsContainer');
+            const badge = $('#alertCountBadge');
+            container.empty();
+
+            badge.text(alerts.length);
+            if (!alerts.length) {
+                container.append('<div class="list-group-item text-center text-muted">目前沒有活躍警報</div>');
+                return;
+            }
+
+            alerts.forEach(function (alert) {
+                const severityBadge = getAlertSeverityBadge(alert.severity);
+                const statusBadge = getAlertStatusBadge(alert.status);
+                const item = `
+                    <div class="list-group-item">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <h6 class="mb-1">${alert.title}</h6>
+                                <div class="text-muted small mb-1"><i class="fas fa-microchip me-1"></i>${alert.deviceName} (${alert.deviceCode})</div>
+                                <p class="mb-1 small">${alert.message}</p>
+                                <div class="text-muted small"><i class="fas fa-clock me-1"></i>${formatDateTime(alert.createdAt)}</div>
+                            </div>
+                            <div class="text-end">
+                                ${severityBadge}
+                                <div class="mt-2">${statusBadge}</div>
+                            </div>
+                        </div>
+                    </div>`;
+
+                container.append(item);
+            });
+        }
+
+        function simulateRandomReading() {
+            if (!cachedDevices.length) {
+                showAlert('目前沒有可用的設備資料', 'warning');
+                return;
+            }
+
+            const activeDevices = cachedDevices.filter(device => device.status === 'Active');
+            const targetList = activeDevices.length ? activeDevices : cachedDevices;
+            const device = targetList[Math.floor(Math.random() * targetList.length)];
+
+            const baseValue = device.lastReadingValue || 0;
+            const increment = device.meterType === 'Electric' ? (Math.random() * 40 + 10) : (Math.random() * 3 + 0.8);
+            const newReadingValue = Number((baseValue + increment).toFixed(2));
+
+            const payload = {
+                deviceId: device.id,
+                consumption: newReadingValue,
+                batteryLevel: device.batteryLevel !== null && device.batteryLevel !== undefined
+                    ? Number(Math.max(0, Math.min(100, device.batteryLevel - Math.random() * 1.5)).toFixed(1))
+                    : Number((90 + Math.random() * 5).toFixed(1)),
+                rssi: Math.round((device.signalStrength ?? -90) + (Math.random() * 6 - 3)),
+                snr: Number(((device.snr ?? 8) + (Math.random() * 2 - 1)).toFixed(1)),
+                temperature: Number((20 + Math.random() * 10).toFixed(1)),
+                packetLossRate: Number((Math.random() * 5).toFixed(1)),
+                valveStatus: device.supportsValveControl ? (Math.random() > 0.1 ? 'Open' : 'Closed') : 'N/A',
+                isConfirmed: true
+            };
+
+            $.ajax({
+                url: '/api/lorasystem/readings',
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify(payload)
+            })
+            .done(function () {
+                loadStats();
+                loadDevices();
+                loadAlerts();
+                loadLatestReadings();
+                showAlert(`已新增 ${device.deviceName} 的即時抄表資料`, 'success');
+            })
+            .fail(function () {
+                showAlert('新增抄表資料失敗，請稍後再試', 'danger');
+            });
+        }
+
+        function renderBatteryBar(level) {
+            if (level === null || level === undefined) {
+                return '<span class="text-muted">-</span>';
+            }
+
+            const percentage = Math.max(0, Math.min(100, level));
+            const badgeClass = percentage >= 60 ? 'bg-success' : (percentage >= 30 ? 'bg-warning text-dark' : 'bg-danger');
+
+            return `
+                <div class="d-flex align-items-center gap-2">
+                    <div class="progress flex-grow-1" style="height: 6px;">
+                        <div class="progress-bar ${badgeClass}" role="progressbar" style="width: ${percentage}%"></div>
+                    </div>
+                    <span class="small fw-semibold">${percentage.toFixed(1)}%</span>
+                </div>`;
+        }
+
+        function renderSignalBadge(signal) {
+            if (signal === null || signal === undefined) {
+                return '<span class="text-muted">-</span>';
+            }
+
+            let badgeClass = 'bg-success';
+            if (signal <= -110) {
+                badgeClass = 'bg-danger';
+            } else if (signal <= -100) {
+                badgeClass = 'bg-warning text-dark';
+            }
+
+            return `<span class="badge ${badgeClass}">${signal} dBm</span>`;
+        }
+
+        function renderFeatureBadges(device) {
+            const badges = [];
+            if (device.supportsValveControl) {
+                badges.push('<span class="badge bg-primary me-1">閥控</span>');
+            }
+            if (device.supportsTwoWayCommunication) {
+                badges.push('<span class="badge bg-info text-dark">雙向</span>');
+            }
+            if (badges.length === 0) {
+                return '<span class="text-muted small">-</span>';
+            }
+            return badges.join('');
+        }
+
+        function renderCoordinateBadge(device) {
+            if (device.latitude === null || device.latitude === undefined || device.longitude === null || device.longitude === undefined) {
+                return '';
+            }
+            return `<span class="badge bg-light text-muted fw-normal"><i class="fas fa-location-arrow me-1"></i>${device.latitude.toFixed(4)}, ${device.longitude.toFixed(4)}</span>`;
+        }
+
+        function getDeviceStatusBadge(status) {
+            switch ((status || '').toLowerCase()) {
+                case 'active':
+                    return '<span class="badge bg-success">運作中</span>';
+                case 'maintenance':
+                    return '<span class="badge bg-warning text-dark">維護中</span>';
+                case 'offline':
+                    return '<span class="badge bg-danger">離線</span>';
+                default:
+                    return '<span class="badge bg-secondary">未知</span>';
+            }
+        }
+
+        function getGatewayStatusBadge(status) {
+            switch ((status || '').toLowerCase()) {
+                case 'online':
+                    return '<span class="badge bg-success">在線</span>';
+                case 'maintenance':
+                    return '<span class="badge bg-warning text-dark">維護</span>';
+                case 'offline':
+                    return '<span class="badge bg-danger">離線</span>';
+                default:
+                    return '<span class="badge bg-secondary">未知</span>';
+            }
+        }
+
+        function getAlertSeverityBadge(severity) {
+            switch ((severity || '').toLowerCase()) {
+                case 'high':
+                    return '<span class="badge bg-danger">高風險</span>';
+                case 'medium':
+                    return '<span class="badge bg-warning text-dark">中等</span>';
+                case 'low':
+                    return '<span class="badge bg-info text-dark">提醒</span>';
+                default:
+                    return '<span class="badge bg-secondary">一般</span>';
+            }
+        }
+
+        function getAlertStatusBadge(status) {
+            switch ((status || '').toLowerCase()) {
+                case 'active':
+                    return '<span class="badge bg-danger">待處理</span>';
+                case 'acknowledged':
+                    return '<span class="badge bg-warning text-dark">已確認</span>';
+                case 'resolved':
+                    return '<span class="badge bg-success">已結案</span>';
+                default:
+                    return '<span class="badge bg-secondary">未知</span>';
+            }
+        }
+
+        function getMeterUnit(meterType) {
+            switch ((meterType || '').toLowerCase()) {
+                case 'water':
+                    return 'm³';
+                case 'gas':
+                    return 'm³';
+                case 'electric':
+                    return 'kWh';
+                default:
+                    return '讀值';
+            }
+        }
+
+        function getMeterUnitFromDevice(deviceId) {
+            const device = cachedDevices.find(d => d.id === deviceId);
+            return device ? getMeterUnit(device.meterType) : '讀值';
+        }
+
+        function formatNumber(value, fractionDigits) {
+            if (value === null || value === undefined || isNaN(value)) {
+                return '-';
+            }
+            return Number(value).toLocaleString('zh-TW', {
+                minimumFractionDigits: fractionDigits,
+                maximumFractionDigits: fractionDigits
+            });
+        }
+
+        function formatDateTime(value) {
+            if (!value) {
+                return '-';
+            }
+            const date = new Date(value);
+            if (isNaN(date.getTime())) {
+                return '-';
+            }
+            return date.toLocaleString('zh-TW', {
+                hour12: false
+            });
+        }
+
+        function debounce(func, wait) {
+            let timeout;
+            return function (...args) {
+                clearTimeout(timeout);
+                timeout = setTimeout(() => func.apply(this, args), wait);
+            };
+        }
+
+        function showAlert(message, type) {
+            const alertHtml = `
+                <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+                    ${message}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>`;
+
+            const container = $('main');
+            container.find('.alert').remove();
+            container.prepend(alertHtml);
+
+            setTimeout(function () {
+                container.find('.alert').fadeOut(500, function () {
+                    $(this).remove();
+                });
+            }, 5000);
+        }
+    </script>
+}

--- a/AspNetCore8Test/Views/Shared/_Layout.cshtml
+++ b/AspNetCore8Test/Views/Shared/_Layout.cshtml
@@ -85,6 +85,11 @@
                                 <i class="fas fa-clipboard-check me-1"></i>簽核管理
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="LoRa" asp-action="Index">
+                                <i class="fas fa-broadcast-tower me-1"></i>LoRa 抄表
+                            </a>
+                        </li>
                         <li class="nav-item dropdown">
                             <button class="btn nav-link dropdown-toggle text-dark border-0 bg-transparent" id="parkDropdown" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 <i class="fas fa-tree me-1"></i>碧湖公園管理


### PR DESCRIPTION
## Summary
- add in-memory LoRa microcomputer metering domain models, DTOs, and service with seeded gateways, devices, readings, and alert logic
- expose new API endpoints for LoRa statistics, devices, meter readings, and alerts and register the service with the application
- create a dashboard-style LoRa management view with filtering, live tables, and navigation entry to access the module

## Testing
- dotnet build AspNetCore8Test.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6815cea8833288d9fc687ba634b6