### PR TITLE
Add LoRa management system menu with multi-version prototypes

### DIFF
--- a/AspNetCore8Test/Controllers/LoRaController.cs
+++ b/AspNetCore8Test/Controllers/LoRaController.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCore8Test.Controllers;
+
+/// <summary>
+/// LoRa 管理系統情境展示控制器。
+/// </summary>
+public class LoRaController : Controller
+{
+    /// <summary>
+    /// 將根路徑導向至第一版頁面，方便快速預覽。
+    /// </summary>
+    public IActionResult Index()
+    {
+        return RedirectToAction(nameof(Version1));
+    }
+
+    /// <summary>
+    /// LoRa 管理系統版本一：著重即時監控與網路健康狀態。
+    /// </summary>
+    public IActionResult Version1()
+    {
+        return View();
+    }
+
+    /// <summary>
+    /// LoRa 管理系統版本二：聚焦事件追蹤與維運排程。
+    /// </summary>
+    public IActionResult Version2()
+    {
+        return View();
+    }
+
+    /// <summary>
+    /// LoRa 管理系統版本三：強化設備生命週期與空間統計分析。
+    /// </summary>
+    public IActionResult Version3()
+    {
+        return View();
+    }
+
+    /// <summary>
+    /// LoRa 管理系統版本四：指揮中心式主題，整合全域概況與自動化策略。
+    /// </summary>
+    public IActionResult Version4()
+    {
+        return View();
+    }
+}

--- a/AspNetCore8Test/Views/LoRa/Version1.cshtml
+++ b/AspNetCore8Test/Views/LoRa/Version1.cshtml
@@ -1,0 +1,274 @@
+@{
+    ViewData["Title"] = "LoRa管理系統(一)";
+    Layout = "_Layout";
+}
+
+<div class="container-fluid lora-v1">
+    <!-- 頁首資訊 -->
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="card shadow-lg border-0 overflow-hidden">
+                <div class="card-body p-4 position-relative">
+                    <div class="row align-items-center">
+                        <div class="col-lg-8">
+                            <h2 class="fw-bold text-white mb-2"><i class="fas fa-satellite-dish me-2"></i>LoRa 管理系統 - 即時監控中心</h2>
+                            <p class="text-white-50 mb-0">掌握閘道器與終端節點的連線狀態、傳輸品質與警示通知，協助維運人員快速反應。</p>
+                        </div>
+                        <div class="col-lg-4 text-lg-end mt-3 mt-lg-0">
+                            <div class="text-white-50 small">最後更新時間</div>
+                            <div class="fs-4 text-white">@DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss")</div>
+                            <span class="badge bg-success-subtle text-success">連線正常</span>
+                        </div>
+                    </div>
+                    <i class="fas fa-wave-square position-absolute opacity-25 display-1 top-50 end-0 translate-middle-y text-white"></i>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 即時指標 -->
+    <div class="row g-3 mb-4">
+        <div class="col-xl-3 col-md-6">
+            <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body d-flex align-items-center">
+                    <div class="icon-circle bg-primary-subtle text-primary me-3">
+                        <i class="fas fa-broadcast-tower"></i>
+                    </div>
+                    <div>
+                        <div class="text-muted text-uppercase small">線上閘道器</div>
+                        <div class="fs-4 fw-bold">18/20</div>
+                        <div class="text-success small"><i class="fas fa-arrow-up"></i> 較昨日 +2</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body d-flex align-items-center">
+                    <div class="icon-circle bg-success-subtle text-success me-3">
+                        <i class="fas fa-signal"></i>
+                    </div>
+                    <div>
+                        <div class="text-muted text-uppercase small">平均訊號強度</div>
+                        <div class="fs-4 fw-bold">-92 dBm</div>
+                        <div class="text-success small"><i class="fas fa-check-circle"></i> 達標</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body d-flex align-items-center">
+                    <div class="icon-circle bg-warning-subtle text-warning me-3">
+                        <i class="fas fa-network-wired"></i>
+                    </div>
+                    <div>
+                        <div class="text-muted text-uppercase small">日封包量</div>
+                        <div class="fs-4 fw-bold">52,340</div>
+                        <div class="text-warning small"><i class="fas fa-exclamation-triangle"></i> 峰值 70%</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body d-flex align-items-center">
+                    <div class="icon-circle bg-danger-subtle text-danger me-3">
+                        <i class="fas fa-bug"></i>
+                    </div>
+                    <div>
+                        <div class="text-muted text-uppercase small">告警事件</div>
+                        <div class="fs-4 fw-bold">3</div>
+                        <div class="text-danger small"><i class="fas fa-clock"></i> 待處理 2 件</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <!-- 網路健康度 -->
+        <div class="col-xl-4">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-transparent border-0">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-heartbeat text-danger me-2"></i>網路健康度</h5>
+                </div>
+                <div class="card-body">
+                    <div class="mb-4">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span class="fw-semibold">封包成功率</span>
+                            <span class="text-success">98.6%</span>
+                        </div>
+                        <div class="progress" style="height: 6px;">
+                            <div class="progress-bar bg-success" role="progressbar" style="width: 98.6%"></div>
+                        </div>
+                    </div>
+                    <div class="mb-4">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span class="fw-semibold">平均延遲</span>
+                            <span class="text-warning">420 ms</span>
+                        </div>
+                        <div class="progress" style="height: 6px;">
+                            <div class="progress-bar bg-warning" role="progressbar" style="width: 65%"></div>
+                        </div>
+                    </div>
+                    <div>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span class="fw-semibold">耗電狀態</span>
+                            <span class="text-info">74% 節點良好</span>
+                        </div>
+                        <div class="progress" style="height: 6px;">
+                            <div class="progress-bar bg-info" role="progressbar" style="width: 74%"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 閘道器狀態 -->
+        <div class="col-xl-4">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-transparent border-0">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-server text-primary me-2"></i>閘道器狀態總覽</h5>
+                </div>
+                <div class="card-body">
+                    <ul class="list-group list-group-flush">
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            北區-01
+                            <span class="badge bg-success">運作中</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            北區-02
+                            <span class="badge bg-success">運作中</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            中區-03
+                            <span class="badge bg-warning text-dark">封包延遲</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            南區-04
+                            <span class="badge bg-danger">離線</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            南區-05
+                            <span class="badge bg-success">運作中</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <!-- 告警與事件 -->
+        <div class="col-xl-4">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-transparent border-0">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-exclamation-circle text-danger me-2"></i>最新告警</h5>
+                </div>
+                <div class="card-body">
+                    <div class="alert alert-danger d-flex align-items-center" role="alert">
+                        <i class="fas fa-bolt me-2"></i>
+                        <div>
+                            閘道器南區-04 於 10 分鐘前離線，請儘速安排現場檢修。
+                        </div>
+                    </div>
+                    <div class="alert alert-warning d-flex align-items-center" role="alert">
+                        <i class="fas fa-battery-quarter me-2"></i>
+                        <div>
+                            感測節點 #A1025 電量低於 20%，建議進行電池更換。
+                        </div>
+                    </div>
+                    <div class="alert alert-info d-flex align-items-center mb-0" role="alert">
+                        <i class="fas fa-info-circle me-2"></i>
+                        <div>
+                            自動頻率調整已於 5 分鐘前啟用，正在觀察干擾狀況。
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 傳輸紀錄 -->
+    <div class="row mt-4">
+        <div class="col-12">
+            <div class="card shadow-sm border-0">
+                <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-stream text-primary me-2"></i>最近 24 小時封包監測</h5>
+                    <span class="badge bg-primary-subtle text-primary">平均成功率 98.6%</span>
+                </div>
+                <div class="card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-7">
+                            <div class="placeholder-wave chart-placeholder">
+                                <span class="placeholder col-12"></span>
+                                <span class="placeholder col-12"></span>
+                                <span class="placeholder col-12"></span>
+                            </div>
+                        </div>
+                        <div class="col-lg-5">
+                            <ul class="list-group list-group-flush small">
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    平均 SNR
+                                    <span class="fw-semibold">8.2 dB</span>
+                                </li>
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    平均上行速率
+                                    <span class="fw-semibold">4.8 kbps</span>
+                                </li>
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    下行成功率
+                                    <span class="fw-semibold">97.4%</span>
+                                </li>
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    重新傳送率
+                                    <span class="fw-semibold text-danger">4.1%</span>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <small class="text-muted d-block mt-3">圖表為樣板展示，可與實際 LoRa 伺服器 API 串接以呈現真實數據。</small>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <style>
+        .lora-v1 .card-body {
+            position: relative;
+        }
+
+        .lora-v1 .card:first-child .card-body {
+            background: linear-gradient(135deg, #4a90e2, #2d59c6);
+        }
+
+        .lora-v1 .icon-circle {
+            width: 3.25rem;
+            height: 3.25rem;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.4rem;
+        }
+
+        .lora-v1 .badge.bg-success-subtle {
+            background-color: rgba(40, 167, 69, 0.15);
+        }
+
+        .chart-placeholder .placeholder {
+            display: block;
+            height: 0.75rem;
+            margin-bottom: 0.75rem;
+        }
+
+        .chart-placeholder .placeholder:nth-child(2) {
+            opacity: 0.7;
+        }
+
+        .chart-placeholder .placeholder:last-child {
+            opacity: 0.4;
+        }
+    </style>
+}

--- a/AspNetCore8Test/Views/LoRa/Version2.cshtml
+++ b/AspNetCore8Test/Views/LoRa/Version2.cshtml
@@ -1,0 +1,328 @@
+@{
+    ViewData["Title"] = "LoRa管理系統(二)";
+    Layout = "_Layout";
+}
+
+<div class="container-fluid lora-v2">
+    <div class="row mb-4 align-items-center">
+        <div class="col-lg-7">
+            <div class="p-4 rounded-4 shadow-sm bg-white position-relative overflow-hidden">
+                <div class="d-flex align-items-center">
+                    <div class="icon-stack bg-gradient text-white me-3">
+                        <i class="fas fa-layer-group"></i>
+                    </div>
+                    <div>
+                        <h2 class="fw-bold mb-1">LoRa 管理系統 - 維運排程中心</h2>
+                        <p class="text-muted mb-0">跨區域頻段配置、排程維護與事件追蹤在此一站式完成，提供不同版本的版面配置體驗。</p>
+                    </div>
+                </div>
+                <div class="floating-badge">
+                    <span class="badge rounded-pill bg-primary">版本 2 Prototype</span>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-5 mt-3 mt-lg-0">
+            <div class="row g-3">
+                <div class="col-6">
+                    <div class="card shadow-sm border-0 h-100 text-center">
+                        <div class="card-body">
+                            <h6 class="text-muted text-uppercase">待排程任務</h6>
+                            <div class="display-6 fw-bold text-primary">12</div>
+                            <span class="text-success small"><i class="fas fa-level-up-alt"></i> 3 新增</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-6">
+                    <div class="card shadow-sm border-0 h-100 text-center">
+                        <div class="card-body">
+                            <h6 class="text-muted text-uppercase">重大事件</h6>
+                            <div class="display-6 fw-bold text-danger">2</div>
+                            <span class="text-danger small"><i class="fas fa-exclamation-circle"></i> 需立即處理</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12">
+                    <div class="card shadow-sm border-0 h-100">
+                        <div class="card-body">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div>
+                                    <div class="text-muted text-uppercase small">網路穩定度</div>
+                                    <div class="h4 fw-bold">92.4%</div>
+                                </div>
+                                <div class="progress flex-grow-1 ms-3" style="height: 8px;">
+                                    <div class="progress-bar bg-info" role="progressbar" style="width: 92.4%"></div>
+                                </div>
+                            </div>
+                            <div class="mt-3 small text-muted">根據最近 7 天指標，北區干擾指數偏高，建議重新調整頻譜。</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <!-- 事件追蹤 -->
+        <div class="col-xl-6">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-route me-2 text-primary"></i>跨區事件追蹤</h5>
+                    <span class="badge bg-light text-primary border">本週 8 件</span>
+                </div>
+                <div class="card-body">
+                    <div class="timeline">
+                        <div class="timeline-item">
+                            <div class="timeline-dot bg-danger"></div>
+                            <div>
+                                <div class="fw-semibold">03/18 09:20 - 南區閘道器離線</div>
+                                <p class="text-muted mb-0 small">自動派單至現場維護組，預計 30 分鐘到場。</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <div class="timeline-dot bg-warning"></div>
+                            <div>
+                                <div class="fw-semibold">03/18 08:45 - 北區干擾偵測</div>
+                                <p class="text-muted mb-0 small">偵測到 LoRaWAN 第 5 信道噪音值偏高，已通知網路工程師。</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <div class="timeline-dot bg-success"></div>
+                            <div>
+                                <div class="fw-semibold">03/18 07:30 - 排程維護完成</div>
+                                <p class="text-muted mb-0 small">更新 120 組節點韌體版本 3.2.1，成功率 100%。</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <div class="timeline-dot bg-info"></div>
+                            <div>
+                                <div class="fw-semibold">03/18 07:05 - 預測性分析</div>
+                                <p class="text-muted mb-0 small">AI 模型預測南區 15% 節點將於一週內需要電池更換。</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 維護排程 -->
+        <div class="col-xl-6">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-calendar-check me-2 text-success"></i>維護排程甘特示意</h5>
+                    <button class="btn btn-sm btn-outline-primary"><i class="fas fa-plus me-1"></i>新增排程</button>
+                </div>
+                <div class="card-body">
+                    <div class="gantt-placeholder">
+                        <div class="gantt-row">
+                            <span class="gantt-label">北區 - 頻段調整</span>
+                            <div class="gantt-bar bg-primary" style="width: 45%; left: 15%">3/18 - 3/19</div>
+                        </div>
+                        <div class="gantt-row">
+                            <span class="gantt-label">中區 - 韌體更新</span>
+                            <div class="gantt-bar bg-success" style="width: 35%; left: 40%">3/20 - 3/21</div>
+                        </div>
+                        <div class="gantt-row">
+                            <span class="gantt-label">南區 - 電池汰換</span>
+                            <div class="gantt-bar bg-warning text-dark" style="width: 55%; left: 10%">3/18 - 3/22</div>
+                        </div>
+                        <div class="gantt-row">
+                            <span class="gantt-label">東區 - 新增節點</span>
+                            <div class="gantt-bar bg-info text-dark" style="width: 30%; left: 60%">3/23 - 3/24</div>
+                        </div>
+                    </div>
+                    <small class="text-muted">甘特圖為概念示意，實際專案可串接 PM 工具或自訂元件。</small>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-1">
+        <div class="col-xl-4">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-transparent border-0">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-chart-pie me-2 text-info"></i>節點分佈概況</h5>
+                </div>
+                <div class="card-body text-center">
+                    <div class="distribution-chart mx-auto mb-3"></div>
+                    <ul class="list-unstyled small mb-0">
+                        <li><span class="legend-dot bg-primary"></span> 北區：640 節點</li>
+                        <li><span class="legend-dot bg-success"></span> 中區：480 節點</li>
+                        <li><span class="legend-dot bg-warning"></span> 南區：520 節點</li>
+                        <li><span class="legend-dot bg-info"></span> 東區：210 節點</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-transparent border-0">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-tools me-2 text-warning"></i>維運清單</h5>
+                </div>
+                <div class="card-body">
+                    <ul class="list-group list-group-flush">
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            設備巡檢任務
+                            <span class="badge bg-light text-secondary">本週 24 件</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            韌體升級
+                            <span class="badge bg-light text-secondary">待確認 8 件</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            AI 預警回覆
+                            <span class="badge bg-light text-secondary">已完成 5 件</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            新增設備申請
+                            <span class="badge bg-light text-secondary">審核中 3 件</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-transparent border-0">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-clipboard-list me-2 text-secondary"></i>版本更新紀錄</h5>
+                </div>
+                <div class="card-body">
+                    <table class="table table-sm align-middle mb-0">
+                        <thead>
+                            <tr class="text-muted">
+                                <th>日期</th>
+                                <th>版本</th>
+                                <th>重點</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>03/17</td>
+                                <td>v3.2.1</td>
+                                <td>AI 預測模組優化</td>
+                            </tr>
+                            <tr>
+                                <td>03/10</td>
+                                <td>v3.1.5</td>
+                                <td>新增跨區排程</td>
+                            </tr>
+                            <tr>
+                                <td>03/02</td>
+                                <td>v3.1.0</td>
+                                <td>支援多頻段策略</td>
+                            </tr>
+                            <tr>
+                                <td>02/20</td>
+                                <td>v3.0.0</td>
+                                <td>全新儀表介面上線</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <style>
+        .lora-v2 {
+            background: linear-gradient(180deg, #f0f4ff 0%, #ffffff 18%);
+            padding-bottom: 2rem;
+        }
+
+        .lora-v2 .icon-stack {
+            width: 4rem;
+            height: 4rem;
+            border-radius: 1.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.75rem;
+        }
+
+        .lora-v2 .bg-gradient {
+            background: linear-gradient(135deg, #5b7cfa, #4351d7);
+        }
+
+        .lora-v2 .floating-badge {
+            position: absolute;
+            top: 1.2rem;
+            right: 1.5rem;
+        }
+
+        .timeline {
+            border-left: 2px solid #e9ecef;
+            padding-left: 1.5rem;
+            position: relative;
+        }
+
+        .timeline-item {
+            display: flex;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+            position: relative;
+        }
+
+        .timeline-dot {
+            width: 0.9rem;
+            height: 0.9rem;
+            border-radius: 50%;
+            position: absolute;
+            left: -1.9rem;
+            top: 0.25rem;
+        }
+
+        .gantt-placeholder {
+            border: 1px dashed #ced4da;
+            border-radius: 0.75rem;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .gantt-row {
+            position: relative;
+            height: 2.75rem;
+            margin-bottom: 1rem;
+            padding-left: 7.5rem;
+            font-size: 0.9rem;
+        }
+
+        .gantt-label {
+            position: absolute;
+            left: 0;
+            top: 0.35rem;
+            width: 7rem;
+            font-weight: 600;
+            color: #495057;
+        }
+
+        .gantt-bar {
+            position: absolute;
+            top: 0.5rem;
+            height: 1.75rem;
+            border-radius: 0.75rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #fff;
+            font-weight: 600;
+            font-size: 0.75rem;
+        }
+
+        .distribution-chart {
+            width: 180px;
+            height: 180px;
+            border-radius: 50%;
+            background: conic-gradient(#4e73df 0 36%, #1cc88a 36% 68%, #f6c23e 68% 100%, #36b9cc 0);
+            box-shadow: inset 0 0 0 18px #fff;
+        }
+
+        .legend-dot {
+            display: inline-block;
+            width: 0.75rem;
+            height: 0.75rem;
+            border-radius: 50%;
+            margin-right: 0.5rem;
+        }
+    </style>
+}

--- a/AspNetCore8Test/Views/LoRa/Version3.cshtml
+++ b/AspNetCore8Test/Views/LoRa/Version3.cshtml
@@ -1,0 +1,312 @@
+@{
+    ViewData["Title"] = "LoRa管理系統(三)";
+    Layout = "_Layout";
+}
+
+<div class="container-fluid lora-v3">
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="card border-0 shadow-sm glass-panel">
+                <div class="card-body p-4">
+                    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                        <div>
+                            <h2 class="fw-bold mb-2 text-primary"><i class="fas fa-chart-network me-2"></i>LoRa 管理系統 - 空間分析版本</h2>
+                            <p class="mb-0 text-muted">結合地理資訊、生命週期管理以及策略儀表板，模擬多維度整合的管理情境。</p>
+                        </div>
+                        <div class="d-flex gap-3">
+                            <div class="stat-chip">
+                                <span class="label">節點總數</span>
+                                <span class="value">1,850</span>
+                            </div>
+                            <div class="stat-chip">
+                                <span class="label">生命週期健康</span>
+                                <span class="value text-success"><i class="fas fa-heartbeat"></i> 87%</span>
+                            </div>
+                            <div class="stat-chip">
+                                <span class="label">版本</span>
+                                <span class="value">3.0 分析</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col-12">
+            <ul class="nav nav-pills flex-wrap gap-2">
+                <li class="nav-item"><span class="nav-link active"><i class="fas fa-layer-group me-1"></i>資產佈署</span></li>
+                <li class="nav-item"><span class="nav-link"><i class="fas fa-sync-alt me-1"></i>生命週期</span></li>
+                <li class="nav-item"><span class="nav-link"><i class="fas fa-user-shield me-1"></i>安全監控</span></li>
+                <li class="nav-item"><span class="nav-link"><i class="fas fa-flask me-1"></i>實驗功能</span></li>
+                <li class="nav-item"><span class="nav-link"><i class="fas fa-cloud-upload-alt me-1"></i>整合 API</span></li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <!-- 空間分布分析 -->
+        <div class="col-xl-8">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-map-marked-alt me-2 text-primary"></i>空間熱區偵測</h5>
+                    <span class="badge bg-primary-subtle text-primary">Last Sync 5 mins ago</span>
+                </div>
+                <div class="card-body">
+                    <div class="heatmap-placeholder mb-3"></div>
+                    <div class="row text-center small text-muted">
+                        <div class="col">
+                            <span class="legend-dot bg-success"></span> 穩定區域
+                        </div>
+                        <div class="col">
+                            <span class="legend-dot bg-warning"></span> 觀察區域
+                        </div>
+                        <div class="col">
+                            <span class="legend-dot bg-danger"></span> 高風險區域
+                        </div>
+                    </div>
+                    <p class="mt-3 mb-0 text-muted small">熱區圖以模擬資料呈現，實務上可串接 GIS 圖資服務或自建地圖模組。</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- 生命週期 -->
+        <div class="col-xl-4">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-header bg-transparent border-0">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-recycle me-2 text-success"></i>設備生命週期</h5>
+                </div>
+                <div class="card-body">
+                    <ul class="list-unstyled life-cycle">
+                        <li>
+                            <span class="stage">部署階段</span>
+                            <div class="progress flex-grow-1">
+                                <div class="progress-bar bg-info" style="width: 100%"></div>
+                            </div>
+                            <span class="ratio">完成</span>
+                        </li>
+                        <li>
+                            <span class="stage">啟用測試</span>
+                            <div class="progress flex-grow-1">
+                                <div class="progress-bar bg-success" style="width: 92%"></div>
+                            </div>
+                            <span class="ratio">92%</span>
+                        </li>
+                        <li>
+                            <span class="stage">穩定運行</span>
+                            <div class="progress flex-grow-1">
+                                <div class="progress-bar bg-primary" style="width: 76%"></div>
+                            </div>
+                            <span class="ratio">76%</span>
+                        </li>
+                        <li>
+                            <span class="stage">優化升級</span>
+                            <div class="progress flex-grow-1">
+                                <div class="progress-bar bg-warning text-dark" style="width: 54%"></div>
+                            </div>
+                            <span class="ratio">54%</span>
+                        </li>
+                        <li>
+                            <span class="stage">退役汰換</span>
+                            <div class="progress flex-grow-1">
+                                <div class="progress-bar bg-danger" style="width: 18%"></div>
+                            </div>
+                            <span class="ratio">18%</span>
+                        </li>
+                    </ul>
+                    <p class="small text-muted mb-0">此區塊示範不同生命週期階段的總覽，可延伸為互動式圖表或 KPI 指標。</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-1">
+        <div class="col-xl-5">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-header bg-transparent border-0">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-project-diagram me-2 text-secondary"></i>LoRa 應用領域概況</h5>
+                </div>
+                <div class="card-body">
+                    <table class="table align-middle mb-0 table-hover">
+                        <thead class="table-light">
+                            <tr>
+                                <th>領域</th>
+                                <th>節點數</th>
+                                <th>上月成長</th>
+                                <th>備註</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><i class="fas fa-city text-primary me-2"></i>智慧城市</td>
+                                <td>620</td>
+                                <td><span class="text-success"><i class="fas fa-arrow-up"></i> 12%</span></td>
+                                <td>新增停車感測專案</td>
+                            </tr>
+                            <tr>
+                                <td><i class="fas fa-industry text-secondary me-2"></i>智慧工廠</td>
+                                <td>430</td>
+                                <td><span class="text-success"><i class="fas fa-arrow-up"></i> 6%</span></td>
+                                <td>導入環境監測</td>
+                            </tr>
+                            <tr>
+                                <td><i class="fas fa-leaf text-success me-2"></i>智慧農業</td>
+                                <td>520</td>
+                                <td><span class="text-warning"><i class="fas fa-minus"></i> 1%</span></td>
+                                <td>進行季節性調整</td>
+                            </tr>
+                            <tr>
+                                <td><i class="fas fa-ship text-info me-2"></i>港口物流</td>
+                                <td>180</td>
+                                <td><span class="text-success"><i class="fas fa-arrow-up"></i> 8%</span></td>
+                                <td>試點智慧倉儲</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-7">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0 fw-bold"><i class="fas fa-lightbulb me-2 text-warning"></i>策略洞察與建議</h5>
+                    <button class="btn btn-sm btn-outline-secondary"><i class="fas fa-download me-1"></i>匯出報告</button>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <div class="insight-card border-start border-4 border-primary p-3 h-100">
+                                <h6 class="fw-bold text-primary mb-2"><i class="fas fa-bolt me-1"></i>自動化調整</h6>
+                                <p class="text-muted mb-0 small">建議針對干擾值高於 50 的區域啟用自動頻道調整策略，提升訊號穩定度。</p>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="insight-card border-start border-4 border-success p-3 h-100">
+                                <h6 class="fw-bold text-success mb-2"><i class="fas fa-battery-full me-1"></i>能源效率</h6>
+                                <p class="text-muted mb-0 small">導入低功耗節點睡眠策略可降低 18% 耗電，延長電池壽命。</p>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="insight-card border-start border-4 border-warning p-3 h-100">
+                                <h6 class="fw-bold text-warning mb-2"><i class="fas fa-shield-alt me-1"></i>安全防護</h6>
+                                <p class="text-muted mb-0 small">強化 OT 安全稽核與 OTA 驗證機制，降低未授權韌體更新風險。</p>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="insight-card border-start border-4 border-info p-3 h-100">
+                                <h6 class="fw-bold text-info mb-2"><i class="fas fa-users me-1"></i>協同效率</h6>
+                                <p class="text-muted mb-0 small">提供跨部門協作看板與 API Webhook，可同步至維運工作流程。</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="alert alert-primary mt-4 mb-0" role="alert">
+                        <strong>版本 3 特點：</strong> 以洞察分析為核心，適合展示資料科學與管理決策面向的 LoRa 方案想像。
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <style>
+        .lora-v3 {
+            background: radial-gradient(circle at top, rgba(93, 135, 255, 0.15), transparent 55%), #f8fbff;
+            padding-bottom: 2.5rem;
+        }
+
+        .glass-panel {
+            background: rgba(255, 255, 255, 0.75);
+            backdrop-filter: blur(12px);
+        }
+
+        .stat-chip {
+            background: #fff;
+            border-radius: 0.85rem;
+            padding: 0.75rem 1rem;
+            min-width: 120px;
+            text-align: center;
+            box-shadow: 0 8px 20px rgba(20, 53, 137, 0.08);
+        }
+
+        .stat-chip .label {
+            font-size: 0.75rem;
+            color: #6c757d;
+            display: block;
+        }
+
+        .stat-chip .value {
+            font-size: 1.1rem;
+            font-weight: 600;
+        }
+
+        .heatmap-placeholder {
+            height: 320px;
+            border-radius: 1rem;
+            background: linear-gradient(135deg, rgba(30, 60, 114, 0.15), rgba(42, 82, 152, 0.1));
+            border: 1px dashed rgba(42, 82, 152, 0.35);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .heatmap-placeholder::before,
+        .heatmap-placeholder::after {
+            content: "";
+            position: absolute;
+            border-radius: 50%;
+            background: radial-gradient(circle, rgba(46, 204, 113, 0.45) 0%, rgba(46, 204, 113, 0) 70%);
+            width: 180px;
+            height: 180px;
+        }
+
+        .heatmap-placeholder::before {
+            top: 40px;
+            left: 50px;
+        }
+
+        .heatmap-placeholder::after {
+            bottom: 20px;
+            right: 60px;
+            background: radial-gradient(circle, rgba(231, 76, 60, 0.45) 0%, rgba(231, 76, 60, 0) 70%);
+        }
+
+        .legend-dot {
+            display: inline-block;
+            width: 0.75rem;
+            height: 0.75rem;
+            border-radius: 50%;
+            margin-right: 0.35rem;
+        }
+
+        .life-cycle li {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            margin-bottom: 0.85rem;
+        }
+
+        .life-cycle .stage {
+            width: 90px;
+            font-weight: 600;
+            color: #495057;
+        }
+
+        .life-cycle .ratio {
+            width: 45px;
+            text-align: end;
+            font-weight: 600;
+            color: #6c757d;
+        }
+
+        .insight-card {
+            background: #fff;
+            border-radius: 0.85rem;
+            box-shadow: 0 0.5rem 1.5rem rgba(15, 61, 145, 0.08);
+        }
+
+        .insight-card h6 {
+            font-size: 0.95rem;
+        }
+    </style>
+}

--- a/AspNetCore8Test/Views/LoRa/Version4.cshtml
+++ b/AspNetCore8Test/Views/LoRa/Version4.cshtml
@@ -1,0 +1,322 @@
+@{
+    ViewData["Title"] = "LoRa管理系統(四)";
+    Layout = "_Layout";
+}
+
+<div class="container-fluid lora-v4 text-white">
+    <div class="command-header mb-4 p-4 rounded-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+            <div>
+                <h2 class="fw-bold mb-2"><i class="fas fa-satellite me-2"></i>LoRa 管理系統 - 指揮中心版</h2>
+                <p class="mb-0 text-white-50">結合全域監控、AI 自動化與戰情板設計，呈現營運指揮中心的視覺感受。</p>
+            </div>
+            <div class="d-flex gap-3">
+                <div class="status-card">
+                    <span class="label">系統狀態</span>
+                    <span class="value text-success"><i class="fas fa-circle"></i> 正常</span>
+                </div>
+                <div class="status-card">
+                    <span class="label">版本</span>
+                    <span class="value">4.0 指揮</span>
+                </div>
+                <div class="status-card">
+                    <span class="label">監控區域</span>
+                    <span class="value">全球 6 區</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 關鍵指標 -->
+    <div class="row g-3 mb-4">
+        <div class="col-xl-3 col-md-6">
+            <div class="info-tile gradient-blue">
+                <div class="label">在線閘道器</div>
+                <div class="value">54</div>
+                <div class="meta text-white-50">+5 vs 昨日</div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="info-tile gradient-green">
+                <div class="label">平均封包成功率</div>
+                <div class="value">99.1%</div>
+                <div class="meta text-white-50">最高 99.7%</div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="info-tile gradient-orange">
+                <div class="label">AI 預測異常</div>
+                <div class="value">4</div>
+                <div class="meta text-white-50">2 件須確認</div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6">
+            <div class="info-tile gradient-red">
+                <div class="label">告警等級</div>
+                <div class="value">Level 2</div>
+                <div class="meta text-white-50">最新：干擾上升</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-xxl-7">
+            <div class="module-card h-100">
+                <div class="module-header">
+                    <h5 class="mb-0"><i class="fas fa-globe-asia me-2"></i>全球戰情概覽</h5>
+                    <span class="badge bg-primary text-uppercase">Realtime</span>
+                </div>
+                <div class="module-body">
+                    <div class="world-map mb-4"></div>
+                    <div class="row g-3 small">
+                        <div class="col-md-4">
+                            <div class="border-start border-3 border-info ps-3">
+                                <div class="text-white-50">北美</div>
+                                <div class="fw-bold">18 閘道器</div>
+                                <div class="text-success">穩定</div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="border-start border-3 border-warning ps-3">
+                                <div class="text-white-50">亞太</div>
+                                <div class="fw-bold">22 閘道器</div>
+                                <div class="text-warning">監控中</div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="border-start border-3 border-danger ps-3">
+                                <div class="text-white-50">歐洲</div>
+                                <div class="fw-bold">14 閘道器</div>
+                                <div class="text-danger">干擾偏高</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xxl-5">
+            <div class="module-card h-100">
+                <div class="module-header">
+                    <h5 class="mb-0"><i class="fas fa-robot me-2"></i>自動化策略控制</h5>
+                    <span class="badge bg-info text-dark">AI Orchestrator</span>
+                </div>
+                <div class="module-body">
+                    <div class="form-check form-switch text-white-50 mb-3">
+                        <input class="form-check-input" type="checkbox" checked>
+                        <label class="form-check-label text-white" for="">動態頻譜管理</label>
+                        <small class="d-block">依據干擾指標自動切換最佳信道。</small>
+                    </div>
+                    <div class="form-check form-switch text-white-50 mb-3">
+                        <input class="form-check-input" type="checkbox" checked>
+                        <label class="form-check-label text-white">節點省電模式</label>
+                        <small class="d-block">智慧調整感測頻率，延長電池壽命。</small>
+                    </div>
+                    <div class="form-check form-switch text-white-50 mb-3">
+                        <input class="form-check-input" type="checkbox">
+                        <label class="form-check-label text-white">自動派工流程</label>
+                        <small class="d-block">自動生成維運任務並推播至現場人員。</small>
+                    </div>
+                    <div class="alert alert-warning bg-opacity-25 border-warning text-warning" role="alert">
+                        <i class="fas fa-exclamation-triangle me-2"></i> 建議開啟「自動派工流程」，以縮短事件處理時間 25%。
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-1">
+        <div class="col-xl-4">
+            <div class="module-card h-100">
+                <div class="module-header">
+                    <h5 class="mb-0"><i class="fas fa-shield-alt me-2"></i>資安態勢</h5>
+                    <span class="badge bg-danger">重點關注</span>
+                </div>
+                <div class="module-body">
+                    <ul class="list-unstyled mb-0 small">
+                        <li class="mb-3">
+                            <span class="fw-semibold">異常登入</span>
+                            <span class="badge bg-danger ms-2">5</span>
+                            <div class="text-white-50">來源：歐洲節點 (已隔離)</div>
+                        </li>
+                        <li class="mb-3">
+                            <span class="fw-semibold">韌體簽章驗證</span>
+                            <span class="badge bg-success ms-2">正常</span>
+                            <div class="text-white-50">所有更新皆通過 Hash 驗證</div>
+                        </li>
+                        <li>
+                            <span class="fw-semibold">VPN 通道</span>
+                            <span class="badge bg-warning text-dark ms-2">負載 67%</span>
+                            <div class="text-white-50">建議評估擴充帶寬</div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="module-card h-100">
+                <div class="module-header">
+                    <h5 class="mb-0"><i class="fas fa-clipboard-check me-2"></i>作業手冊速覽</h5>
+                    <span class="badge bg-secondary">SOP</span>
+                </div>
+                <div class="module-body small">
+                    <ol class="ps-3 mb-0">
+                        <li class="mb-2">確認戰情板告警優先順序並指派指揮官。</li>
+                        <li class="mb-2">檢視 AI 建議策略，調整自動化排程。</li>
+                        <li class="mb-2">同步現場維運與安全團隊資訊。</li>
+                        <li>產生回報文件並備份至雲端。</li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="module-card h-100">
+                <div class="module-header">
+                    <h5 class="mb-0"><i class="fas fa-terminal me-2"></i>即時系統日誌</h5>
+                    <span class="badge bg-light text-dark">Log Stream</span>
+                </div>
+                <div class="module-body">
+                    <div class="log-window">
+                        <div>[09:20:12] Gateway-EU-14 信號干擾值上升。</div>
+                        <div>[09:18:05] AI 預測：北美區電池壽命剩餘 20%。</div>
+                        <div>[09:15:44] 任務派工：派出維運小隊 S2 至亞太區。</div>
+                        <div>[09:14:08] OTA 更新成功：韌體 v4.1.0。</div>
+                        <div>[09:10:30] 安全提醒：異常登入嘗試已封鎖。</div>
+                    </div>
+                    <small class="text-white-50">資料為範例，可串接真實日誌串流服務。</small>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Styles {
+    <style>
+        .lora-v4 {
+            background: radial-gradient(circle at top left, rgba(69, 155, 255, 0.25), transparent 55%), #0b1625;
+            min-height: 100vh;
+            padding-bottom: 2.5rem;
+        }
+
+        .command-header {
+            background: linear-gradient(135deg, rgba(28, 37, 65, 0.9), rgba(26, 61, 114, 0.9));
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .status-card {
+            background: rgba(255, 255, 255, 0.08);
+            border-radius: 0.75rem;
+            padding: 0.75rem 1rem;
+            min-width: 130px;
+            text-align: center;
+        }
+
+        .status-card .label {
+            font-size: 0.75rem;
+            color: rgba(255, 255, 255, 0.55);
+            display: block;
+        }
+
+        .status-card .value {
+            font-weight: 600;
+        }
+
+        .info-tile {
+            border-radius: 1rem;
+            padding: 1.5rem;
+            height: 100%;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+
+        .info-tile .label {
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+            color: rgba(255, 255, 255, 0.55);
+        }
+
+        .info-tile .value {
+            font-size: 2.3rem;
+            font-weight: 700;
+        }
+
+        .info-tile.gradient-blue {
+            background: linear-gradient(135deg, rgba(76, 175, 255, 0.85), rgba(47, 128, 237, 0.95));
+        }
+
+        .info-tile.gradient-green {
+            background: linear-gradient(135deg, rgba(45, 203, 112, 0.85), rgba(29, 160, 87, 0.95));
+        }
+
+        .info-tile.gradient-orange {
+            background: linear-gradient(135deg, rgba(255, 193, 7, 0.9), rgba(255, 140, 0, 0.9));
+        }
+
+        .info-tile.gradient-red {
+            background: linear-gradient(135deg, rgba(244, 67, 54, 0.9), rgba(199, 0, 57, 0.95));
+        }
+
+        .module-card {
+            background: rgba(12, 24, 42, 0.85);
+            border-radius: 1rem;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            box-shadow: 0 1.5rem 3rem rgba(5, 14, 24, 0.5);
+            display: flex;
+            flex-direction: column;
+        }
+
+        .module-header {
+            padding: 1.25rem 1.5rem 0.75rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .module-body {
+            padding: 1.5rem;
+            flex: 1;
+        }
+
+        .world-map {
+            height: 220px;
+            border-radius: 0.85rem;
+            background: radial-gradient(circle at center, rgba(0, 180, 255, 0.35), transparent 65%), url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="2"><path d="M83 160l42 26 46-32 38 14 53-28 59 17 60-35 41 7 54-21 30 33 52-8 44 18 27-9 34 31 40-20 41 22"/></svg>');
+            background-size: cover;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+        }
+
+        .form-check-input:checked {
+            background-color: #1cc88a;
+            border-color: #1cc88a;
+        }
+
+        .form-check-input {
+            cursor: pointer;
+        }
+
+        .alert.bg-opacity-25 {
+            background-color: rgba(255, 193, 7, 0.15) !important;
+        }
+
+        .log-window {
+            background: rgba(9, 20, 35, 0.95);
+            border-radius: 0.75rem;
+            padding: 1rem;
+            font-family: "Fira Code", "Consolas", monospace;
+            font-size: 0.85rem;
+            line-height: 1.5;
+            max-height: 200px;
+            overflow-y: auto;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .log-window::-webkit-scrollbar {
+            width: 6px;
+        }
+
+        .log-window::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.2);
+            border-radius: 3px;
+        }
+    </style>
+}

--- a/AspNetCore8Test/Views/Shared/_Layout.cshtml
+++ b/AspNetCore8Test/Views/Shared/_Layout.cshtml
@@ -320,6 +320,25 @@
                                 </li>
                             </ul>
                         </li>
+                        <li class="nav-item dropdown">
+                            <button class="btn nav-link dropdown-toggle text-dark border-0 bg-transparent" id="loraDropdown" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                <i class="fas fa-broadcast-tower me-1"></i>LoRa管理系統
+                            </button>
+                            <ul class="dropdown-menu" aria-labelledby="loraDropdown">
+                                <li><a class="dropdown-item" asp-controller="LoRa" asp-action="Version1">
+                                    <i class="fas fa-satellite-dish me-2"></i>LoRa管理系統(一)
+                                </a></li>
+                                <li><a class="dropdown-item" asp-controller="LoRa" asp-action="Version2">
+                                    <i class="fas fa-layer-group me-2"></i>LoRa管理系統(二)
+                                </a></li>
+                                <li><a class="dropdown-item" asp-controller="LoRa" asp-action="Version3">
+                                    <i class="fas fa-chart-network me-2"></i>LoRa管理系統(三)
+                                </a></li>
+                                <li><a class="dropdown-item" asp-controller="LoRa" asp-action="Version4">
+                                    <i class="fas fa-globe-asia me-2"></i>LoRa管理系統(四)
+                                </a></li>
+                            </ul>
+                        </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Library" asp-action="Index">
                                 <i class="fas fa-book me-1"></i>圖書館


### PR DESCRIPTION
## Summary
- add a dedicated LoRa controller with actions for four prototype versions of the management portal
- create four themed Razor views that showcase different layouts and information focus areas for the LoRa system
- expose the new pages through a LoRa 管理系統 dropdown in the main navigation

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8423a07c83328ca08a36e69efde7